### PR TITLE
Creation of module for converters. Just a few examples for now.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ sys.path.insert(0, local_path)
 setup(
     name='scikit-hep',
     author='The Scikit-HEP Developers',
-    version='0.0.1dev',
+    version='0.0.1.dev1',
     license='new BSD',
     url='http://github.com/scikit-hep/scikit-hep',
     description='Community-developed Particle Physics analysis toolkit',

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,14 @@ sys.path.insert(0, local_path)
 
 setup(
     name='scikit-hep',
-    version='0.0.1',
+    author='The Scikit-HEP Developers',
+    version='0.0.1dev',
     license='new BSD',
+    url='http://github.com/scikit-hep/scikit-hep',
+    description='Community-developed Particle Physics analysis toolkit',
+    #requires=[
+    #    'root_numpy',
+    #],
     test_suite = "tests",
     classifiers=[
         'Intended Audience :: Science/Research',

--- a/skhep/__init__.py
+++ b/skhep/__init__.py
@@ -15,11 +15,12 @@ A community-driven and oriented Python software project for High Energy Physics.
 #-----------------------------------------------------------------------------
 from __future__ import absolute_import
 
-__all__ = [ 'banner',
-            'project_url',
-            'project_url_GitHub',
-            'project_url_PyPI'
-            ]
+# Information on supported backends
+from .backends import *
+
+# Set of scikit-hep exceptions
+from .exceptions import *
+
 
 #-----------------------------------------------------------------------------
 # Project and package info

--- a/skhep/__init__.py
+++ b/skhep/__init__.py
@@ -25,7 +25,7 @@ from .exceptions import *
 #-----------------------------------------------------------------------------
 # Project and package info
 #-----------------------------------------------------------------------------
-__version__ = '0.0.1'
+__version__ = '0.0.1.dev1'
 
 project_url        = 'http://scikit-hep.org'
 project_url_GitHub = 'https://github.com/scikit-hep/scikit-hep'

--- a/skhep/backends.py
+++ b/skhep/backends.py
@@ -1,0 +1,40 @@
+# Licensed under a 3-clause BSD style license, see LICENSE.
+"""
+Module for backends
+===================
+
+The following backends are supported in Scikit-HEP:
+* ROOT
+* NumPy
+"""
+
+#-----------------------------------------------------------------------------
+# Import statements
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import, print_function
+
+__all__ = [ 'backends', 'backend_converter_mapping' ]
+
+
+#-----------------------------------------------------------------------------
+# Utilities providing information on supported backends and converters
+#-----------------------------------------------------------------------------
+# Set of supported backends
+backends_supported = ( 'root', 'numpy' )
+
+def backends():
+    print( 'Available backends (all names stored in lowercase):' )
+    print( ' '.join(backends_supported) )
+
+def backend_converter_mapping():
+    """
+    Print a matrix of converters among all available backends.
+    """
+    m = """
+    Converters implemented for the supported backends:
+    
+      ROOT          NumPy
+      -----------------------------------
+      TTree   <->   Structured array
+    """
+    print(m)

--- a/skhep/exceptions.py
+++ b/skhep/exceptions.py
@@ -1,0 +1,29 @@
+# Licensed under a 3-clause BSD style license, see LICENSE.
+"""
+Module for Scikit-HEP exceptions
+================================
+
+List of exceptions defined:
+* NotSupportedBackendError: for backends not (yet) supported.
+"""
+
+#-----------------------------------------------------------------------------
+# Import statements
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import
+
+__all__ = [ 'NotSupportedBackendError' ]
+
+
+#-----------------------------------------------------------------------------
+# Definition of available exceptions
+#-----------------------------------------------------------------------------
+class NotSupportedBackendError( NotImplementedError ):
+    """
+    Exception class representing a backend not (yet) implemented.
+    """
+    def __init__( self, location, msg ):
+        self.location, self.msg = location, msg
+    
+    def __str__( self ):
+        return "[%s] %s" % ( self.location, self.msg )

--- a/skhep/to/__init__.py
+++ b/skhep/to/__init__.py
@@ -1,0 +1,17 @@
+# Licensed under a 3-clause BSD style license, see LICENSE.
+"""
+******************************************
+Subpackage for converters between backends
+******************************************
+
+See skhep.backends for details on the available backends.
+"""
+
+#-----------------------------------------------------------------------------
+# Import statements
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import
+
+from .root   import *
+from .numpy  import *
+from .pandas import *

--- a/skhep/to/numpy/__init__.py
+++ b/skhep/to/numpy/__init__.py
@@ -1,0 +1,16 @@
+# Licensed under a 3-clause BSD style license, see LICENSE.
+"""
+**********************************
+Subpackage for converters to NumPy
+**********************************
+
+"""
+
+#-----------------------------------------------------------------------------
+# Import statements
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import
+
+#from root_numpy import tree2array
+
+__all__ = []

--- a/skhep/to/numpy/__init__.py
+++ b/skhep/to/numpy/__init__.py
@@ -11,6 +11,6 @@ Subpackage for converters to NumPy
 #-----------------------------------------------------------------------------
 from __future__ import absolute_import
 
-#from root_numpy import tree2array
+from root_numpy import tree2array
 
-__all__ = []
+__all__ = [ 'tree2array' ]

--- a/skhep/to/numpy/__init__.py
+++ b/skhep/to/numpy/__init__.py
@@ -11,6 +11,6 @@ Subpackage for converters to NumPy
 #-----------------------------------------------------------------------------
 from __future__ import absolute_import
 
-from root_numpy import tree2array
+from root_numpy import tree2array, root2array
 
-__all__ = [ 'tree2array' ]
+__all__ = [ 'tree2array', 'root2array' ]

--- a/skhep/to/pandas/__init__.py
+++ b/skhep/to/pandas/__init__.py
@@ -1,0 +1,24 @@
+# Licensed under a 3-clause BSD style license, see LICENSE.
+"""
+***********************************
+Subpackage for converters to Pandas
+***********************************
+
+"""
+
+#-----------------------------------------------------------------------------
+# Import statements
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import
+
+from skhep.exceptions import NotSupportedBackendError
+
+__all__ = [ 'tree2df' ]
+
+
+#-----------------------------------------------------------------------------
+# Definition of available converters
+#-----------------------------------------------------------------------------
+def tree2df( ttree ):
+    """Converter a TTtree to a DataFrame."""
+    raise NotSupportedBackendError( __name__, 'Pandas converters not yet available!')

--- a/skhep/to/root/__init__.py
+++ b/skhep/to/root/__init__.py
@@ -11,6 +11,6 @@ Subpackage for converters to ROOT
 #-----------------------------------------------------------------------------
 from __future__ import absolute_import
 
-#from root_numpy import array2tree
+from root_numpy import array2tree
 
-__all__ = []
+__all__ = [ 'array2tree' ]

--- a/skhep/to/root/__init__.py
+++ b/skhep/to/root/__init__.py
@@ -1,0 +1,16 @@
+# Licensed under a 3-clause BSD style license, see LICENSE.
+"""
+*********************************
+Subpackage for converters to ROOT
+*********************************
+
+"""
+
+#-----------------------------------------------------------------------------
+# Import statements
+#-----------------------------------------------------------------------------
+from __future__ import absolute_import
+
+#from root_numpy import array2tree
+
+__all__ = []


### PR DESCRIPTION
Hi everyone,
To move forward I gave the converters a first stab, and created a module with a few examples from ROOT <-> NumPy converters as provided by root_numpy. This should be enough for a discussion.
Basic usage proposed is the following:

>>> from skhep import to
>>> # TTree -> NumPy structured array
>>> myarray = to.numpy.tree2array(mytree,...)
>>> # Back to TTree
>>> mytree = to.root.array2tree(myarray,...)

To be this code is easy to read and is self-explanatory.
There are other possibilities that I also tried, including a universal way of calling the converters. But it hides a bit too much for my taste. In any case what I committed is more than enough for a kick-off.
Please comment on this PR.
Thanks,
Eduardo
