### PR TITLE
Introduction of MultiProvenance. Modification of NumpyDataset. Introduction of Selection Framework.

### DIFF
--- a/skhep/dataset/numpydataset.py
+++ b/skhep/dataset/numpydataset.py
@@ -565,16 +565,12 @@ class SkhepNumpyArray(numpy.ndarray):
             return self.__array_ufunc__(numpy.true_divide, "__call__", self, other, out=(self,))
             
         def __pow__(self, other):
-            print other
-            print type(other)
             if isinstance(other, (int, float)) and other == 2.0:
                 return self.__array_ufunc__(numpy.square, "__call__", self)
             else:
                 return self.__array_ufunc__(numpy.power, "__call__", self, other)
                 
         def __ipow__(self, other):
-            print other
-            print type(other)
             if isinstance(other, (int, float)) and other == 2.0:
                 return self.__array_ufunc__(numpy.square, "__call__", self, out=(self,))
             else:

--- a/skhep/dataset/numpydataset.py
+++ b/skhep/dataset/numpydataset.py
@@ -576,6 +576,31 @@ class SkhepNumpyArray(numpy.ndarray):
             else:
                 ufunc = numpy.power
                 return self.__array_ufunc__(numpy.power, "__call__", self, other, out=(self,))
+
+
+# -----------------------------------------------------------------------------
+# Add Numpy methods to NumpyDataset in bulk.
+# SkhepNumpyArray
+# -----------------------------------------------------------------------------                
+                
+#def addNumpyMethod(method):
+#    def fn(self, name, *args, **kwds):
+#        return method.__call__(self.data, *args, **kwds)
+#
+#    fn.__name__ = method.__name__
+#    fn.__doc__ = method.__doc__
+#    if sys.version_info[0]==2:  # ugly but works! TODO: find nicer way
+#        setattr(NumpyDataset, method.__name__, MethodType(fn, None, NumpyDataset))
+#    else:
+#        setattr(NumpyDataset, method.__name__, MethodType(fn, NumpyDataset))
+#
+#  try:
+#     addNumpyMethod(numpy.ndarray.__add__)
+#     addNumpyMethod(numpy.ndarray.__mul__)
+#     addNumpyMethod(numpy.ndarray.sum)
+#     addNumpyMethod(numpy.ndarray.mean)
+#  except ImportError:
+#    pass
             
         
         

--- a/skhep/dataset/numpydataset.py
+++ b/skhep/dataset/numpydataset.py
@@ -90,7 +90,7 @@ class NumpyDataset(FromFiles, ToFiles, NewROOT, Dataset):
                 selection = Selection(selection)
                 
             data = self.data[ selection.numpyselection(self) ]
-            provenance = self._provenance + Transformation("Selection, {}, applied".format(selection))
+            provenance = self._provenance + Transformation("Selection, {0}, applied".format(selection))
             return NumpyDataset(data, provenance)
         else:
             raise ValueError("selection input must be of type 'str', 'Selection', or an Array of booleans not {0}".format(type(selection)))
@@ -208,7 +208,7 @@ class NumpyDataset(FromFiles, ToFiles, NewROOT, Dataset):
         """
 
 #        if self.isrecarray(self.data):
-        data = self.data
+#        data = self.data
 #        elif self.isdictof1d(self.data):
 #            data = numpy.empty(head(self.data.values()).shape,
 #                               dtype=[(name, self.data[name].dtype) for name in self.data])
@@ -231,7 +231,7 @@ class NumpyDataset(FromFiles, ToFiles, NewROOT, Dataset):
             # return a copy in order to avoid unrecorded operation due to ndarray mutability
         elif isinstance(object, SkhepNumpyArray) and object.dtype == bool:
             data = self.data[ object ]
-            provenance = self.provenance + Transformation("Subsetting dataset: {}".format(object.name), object.name)
+            provenance = self.provenance + Transformation("Subsetting dataset: {0}".format(object.name), object.name)
             return NumpyDataset(data, provenance)
         else:
             return self.data[object]
@@ -247,7 +247,7 @@ class NumpyDataset(FromFiles, ToFiles, NewROOT, Dataset):
                 detail = getattr(value, 'provenance', None)
                 data = recfunctions.append_fields(self.data , name, value, usemask=False)
                 self._data  = data
-                self._provenance += Transformation("Array {} has been created".format(name), detail)
+                self._provenance += Transformation("Array {0} has been created".format(name), detail)
                 self.__add_var(name)
         else:
             dict.__setattr__(self, name, value)
@@ -355,7 +355,7 @@ class SkhepNumpyArray(numpy.ndarray):
         elif isinstance(provenance, Provenance):
             self._provenance = MultiProvenance(provenance)
         else:
-            raise NotImplementedError
+            raise ValueError("Inputs must be Provenance types!")
         
     @name.setter
     def name(self, name):
@@ -403,9 +403,9 @@ class SkhepNumpyArray(numpy.ndarray):
                 
                 for ni in names_input:
                     if ni == names_input[-1]:
-                        name += " {} )".format(ni)
+                        name += " {0} )".format(ni)
                     else:
-                        name += " {},".format(ni)
+                        name += " {0},".format(ni)
 
                 provenance = ObjectOrigin(name) 
                 

--- a/skhep/dataset/numpydataset.py
+++ b/skhep/dataset/numpydataset.py
@@ -25,7 +25,8 @@ from types import MethodType
 from ..utils.py23 import *
 from ..utils.decorators import inheritdoc
 from ..utils.dependencies import softimport
-from ..utils.provenance import FileOrigin, ObjectOrigin, Transformation, Formatting
+from ..utils.provenance import FileOrigin, ObjectOrigin, Transformation, Formatting, MultiProvenance, Provenance
+from ..dataset.selection import Selection
 
 from .defs import *
 
@@ -46,13 +47,54 @@ class NumpyDataset(FromFiles, ToFiles, NewROOT, Dataset):
         provenance: history of the data before being wrapped as a NumpyDataset.
         options: none.
         """
+        
         assert self.isrecarray(data) or self.isdictof1d(data)
         self._data = data
+        if isinstance(data, dict):
+            self.dicttoarray()
+        
+        for var in self.data.dtype.names:
+            self.__add_var(var)
+            
+        if isinstance(provenance, MultiProvenance):
+            self._provenance = provenance.copy()
+        else:
+            if provenance is None:
+                provenance = ObjectOrigin(repr(data))
+            if not isinstance(provenance, ( list, tuple ) ):
+                provenance = [provenance]
+            
+            self._provenance = MultiProvenance(*provenance)
+        
+    def copy(self) :
+        """Get a copy of the NumpyDataset."""
+        return NumpyDataset( self._data, self._provenance )
+        
+    def select(self, selection = None):
+        """
+        Apply a selection to the NumpyDataset.
+        
+        Parameters
+        ----------
+        selection: Selection or str
 
-        if provenance is None:
-            provenance = ObjectOrigin(repr(data))
-        self._provenance = provenance
-
+        Returns
+        -------
+        new NumpyDataset after selection
+        """
+  
+        if isinstance(selection, numpy.ndarray) and selection.dtype == bool:
+            return self.__getitem__(selection)
+        elif isinstance(selection, Selection) or isinstance(selection, str):
+            if isinstance(selection, str):
+                selection = Selection(selection)
+                
+            data = self._data[ selection.numpyselection(self) ]
+            provenance = self._provenance + Transformation("Selection, {}, applied".format(selection))
+            return NumpyDataset(data, provenance)
+        else:
+            raise ValueError("selection input must be of type 'str', 'Selection', or an Array of booleans not {0}".format(type(selection)))
+                              
     @staticmethod
     def isrecarray(data):
         is_valid_recarray = isinstance(data, numpy.recarray)
@@ -69,7 +111,19 @@ class NumpyDataset(FromFiles, ToFiles, NewROOT, Dataset):
                                      for column in data.values())
         columns_have_valid_shape = all(column.shape == head(data.values()).shape for column in data.values())
         return is_dict and is_non_empty and has_only_valid_columns and columns_have_valid_shape
-
+        
+    def dicttoarray(self):
+        """Convert a dictionnary into a structured array."""
+        if self.isdictof1d(self._data) and not self.isrecarray(self._data):
+            dtypes = {'names': self._data.keys(), 'formats': [numpy.dtype(self._data[k].dtype) for k in self._data.keys()]}
+            shape  = (len(self._data.values()[0]),)
+            array  = numpy.zeros(shape,dtypes)
+            
+            for k in self._data.keys():
+                array[k] = self._data[k]
+                
+            self._data = array
+            
     @property
     @inheritdoc(Dataset)
     def datashape(self):
@@ -134,11 +188,11 @@ class NumpyDataset(FromFiles, ToFiles, NewROOT, Dataset):
         """options: none"""
         # always write column-wise: collection of 1d arrays in a zip file (.npz)
         # (not too different from what ROOT is, actually)
-        if self.isrecarray(self.data):
-            data = dict((name, self.data[name])
-                        for name in self.data.dtype.names)
+        if self.isrecarray(self._data):
+            data = dict((name, self._data[name])
+                        for name in self._data.dtype.names)
         else:
-            data = self.data
+            data = self._data
         numpy.savez(NumpyDataset._openSingleFile(base), **data)
 
     @inheritdoc(NewROOT, gap='')
@@ -155,42 +209,270 @@ class NumpyDataset(FromFiles, ToFiles, NewROOT, Dataset):
         ROOTDataset holding new ROOT TTree.
         """
 
-        if self.isrecarray(self.data):
-            data = self.data
-        elif self.isdictof1d(self.data):
+        if self.isrecarray(self._data):
+            data = self._data
+        elif self.isdictof1d(self._data):
             data = numpy.empty(head(self._data.values()).shape,
-                               dtype=[(name, self.data[name].dtype) for name in self.data])
-            for name in self.data:
-                data[name] = self.data[name]
+                               dtype=[(name, self._data[name].dtype) for name in self._data])
+            for name in self._data:
+                data[name] = self._data[name]
         else:
             assert False, "data must be a Numpy record array or a Python dictionary of 1d Numpy arrays."
 
-        tree = root_numpy.array2tree(self.data, treeename)
+        tree = root_numpy.array2tree(self._data, treename)
         from .rootdataset import ROOTDataset
-        return ROOTDataset(tree, self._provenance+(Formatting('ROOTDataset', treename),))
+        return ROOTDataset(tree, self._provenance+Formatting('ROOTDataset', treename))
 
-    def __getitem__(self, name):
-        return self.data[name]
+    def __getitem__(self, object):
+        
+        if isinstance(object, str) and object in self.__dict__.keys():
+            array = self.data[object].view(SkhepNumpyArray)
+            array.name = object
+            array.provenance = ObjectOrigin(repr(self))
+            return array.copy()
+            # return a copy in order to avoid unrecorded operation due to ndarray mutability
+        elif isinstance(object, SkhepNumpyArray) and object.dtype == bool:
+            data = self._data[ object ]
+            provenance = self._provenance + Transformation("Subsetting dataset: {}".format(object.name), object.name)
+            return NumpyDataset(data, provenance)
+        else:
+            return self.data[object]
+                
+    def __setattr__(self, name, value):
+        listofattributes = self.__dict__.keys()
+        
+        if isinstance(value, numpy.ndarray) and name != "_data" and name not in listofattributes :
+            if value.shape != self._data.shape:
+                raise ValueError('Arrays should have the same dimensions')
+            else:
+                from numpy.lib import recfunctions
+                detail = getattr(value, 'provenance', None)
+                data = recfunctions.append_fields(self._data, name, value, usemask=False)
+                self._data = data
+                self._provenance += Transformation("Array {} has been created".format(name), detail)
+                self.__add_var(name)
+        else:
+            dict.__setattr__(self, name, value)
+        
+        
+    def __setitem__(self, name, array):
+        listofattributes = self.__dict__.keys()
+        
+        if isinstance(array, numpy.ndarray):
+            if name not in listofattributes:
+                self.__setattr__(name, array)
+            elif name != "_data":
+                if array.shape != self.data[name].shape:
+                    raise ValueError('Arrays should have the same dimensions')
+                if isinstance(array, SkhepNumpyArray) and array.provenance[0].detail == repr(self) and array.name == name: 
+                    self._data[name] = array.view(numpy.ndarray)
+                    self._provenance += MultiProvenance(*array.provenance[1:])                    
+                else:
+                    array_name = getattr(array, 'name', None)
+                    if array_name is None: array_name = repr(array)
+                    detail = getattr(array, 'provenance', None)
+                    self._data[name] = array
+                    self._provenance += Transformation("Array {0} as been replaced by {1}".format(name, array_name), detail)
+        else:
+            raise ValueError('Not an array!')
+                            
+    def __add_var(self, var):
+        """Add columns of the array as property attributes"""
+        def make_get_set(var):
+            def getter(self):
+                return self.__getitem__(var)
+            def setter(self, array):
+                self.__setitem__(var, array)
+            return getter, setter
+                                    
+        setattr(NumpyDataset, var, property(*make_get_set(var)))
+        self.__dict__[var] = self.data[var]
+        
+    def __repr__(self):
+        """Class representation."""
+        return "NumpyDataset{0}".format(repr(self.data).replace("array",""))
 
+    def __str__(self):
+        """Simple class representation."""
+        return str(self.data)
+    
+        
+# -----------------------------------------------------------------------------
+# SkhepNumpyArray
+# -----------------------------------------------------------------------------
+            
+class SkhepNumpyArray(numpy.ndarray):
+    def __new__(cls, inputarray, name=None, provenance=None):
+        """Default constructor for SkhepNumpyArray.
 
+        Parameters
+        ----------
+        input_array: numpy array, list or tuple.
+        name: name of the variable.
+        provenance: history of the variable.
+        """
+                
+        instance = numpy.asarray(inputarray).view(cls)
+        instance._name  = name
+        
+        if isinstance(provenance, MultiProvenance):
+            instance._provenance = provenance.copy()
+        else:
+            if provenance is None:
+                provenance = ObjectOrigin(repr(inputarray))
+            if not isinstance(provenance, ( list, tuple ) ):
+                provenance = [provenance]
+            instance._provenance = MultiProvenance(*provenance)
+            
+        return instance
+     
+    @inheritdoc(numpy.ndarray)    
+    def __array_finalize__(self, obj):        
+        if obj is None: return
+        self._name = getattr(obj, 'name', None)
+        self._provenance = getattr(obj, 'provenance', MultiProvenance(ObjectOrigin(repr(obj))))
+                
+        
+    def copy(self):
+        """Get a copy of the SkhepNumpyArray."""
+        return SkhepNumpyArray(numpy.copy(self), name = self._name, provenance = self._provenance)
+                        
+    @property
+    def name(self):
+        """Return the name of the variable inside the SkhepNumpyArray."""
+        return self._name
+        
+    @property
+    def provenance(self):
+        """Return the provenance of the SkhepNumpyArray."""
+        return self._provenance
+        
+    @provenance.setter
+    def provenance(self, provenance):
+        """Sets the provenance of the SkhepNumpyArray."""
+        if isinstance(provenance, MultiProvenance):
+            self._provenance = provenance
+        elif isinstance(provenance, Provenance):
+            self._provenance = MultiProvenance(provenance)
+        else:
+            raise NotImplementedError
+        
+    @name.setter
+    def name(self, name):
+        """Sets the name of the variable inside the SkhepNumpyArray."""
+        self._name = name
+     
+    @inheritdoc(numpy.ndarray)   
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+               
+        args = []
+        names_input = []
+        for _input in inputs:
+            if hasattr(_input, "name"):
+                names_input.append(_input.name)
+            else:
+                names_input.append(repr(_input))
+            args.append(numpy.asarray(_input))
+                
+        outputs = kwargs.pop('out', None)
+        if outputs:
+            out_args = []
+            for o in outputs:
+                out_args.append(numpy.asarray(o))
+            kwargs['out'] = tuple(out_args)
+            
+        name       = self.name
+        provenance = self.provenance
+        result = getattr(ufunc, method)(*args, **kwargs)
+    
+        if ufunc != numpy.logical_and and ufunc != numpy.logical_or:
+            result = result.view(SkhepNumpyArray)
+            
+            #min max
+            if ufunc == numpy.maximum or ufunc == numpy.minimum:
+                if ufunc == numpy.maximum:
+                    name = "max("
+                if ufunc == numpy.maximum:
+                    name = "min("
+                
+                for ni in names_input:
+                    if ni == names_input[-1]:
+                        name += " {} )".format(ni)
+                    else:
+                        name += " {},".format(ni)
+
+                provenance = ObjectOrigin(name) 
+                
+            #comparison operators
+            comparisaton_operators = {"<ufunc 'greater'>": ">", "<ufunc 'less'>": "<", "<ufunc 'greater_equal'>": ">=", "<ufunc 'less_equal'>": "<=",
+                    "<ufunc 'equal'>": "==", "<ufunc 'not_equal'>": "!=", "<ufunc 'bitwise_and'>": "&", "<ufunc 'bitwise_or'>": "|"}
+            
+            if str(ufunc) in comparisaton_operators.keys():
+                op = comparisaton_operators[str(ufunc)]
+                lhs = names_input[0]
+                rhs = names_input[1]
+                
+                if op == "&" or op == "|":
+                    lhs = "("+lhs+")"
+                    rhs = "("+rhs+")"
+                
+                name = "{0} {1} {2}".format(lhs, op, rhs)
+                provenance = ObjectOrigin(name)
+                
+            #arithmetic operators
+            arithmetic_operators = {"<ufunc 'add'>": "+", "<ufunc 'subtract'>": "-", "<ufunc 'multiply'>": "*", "<ufunc 'divide'>": "/",
+                        "<ufunc 'power'>": "^"}
+            
+            if ufunc == numpy.square:
+                name = "{0}^2".format(names_input[0])
+                provenance = ObjectOrigin(name)
+                
+            if str(ufunc) in arithmetic_operators.keys():
+                op = arithmetic_operators[str(ufunc)]
+                lhs = names_input[0]
+                rhs = names_input[1]
+                
+                # __add__
+                if op == "+":
+                    provenance += Transformation("{1} as been added to {0}".format(lhs, rhs))
+                # __sub__
+                elif op == "-":
+                    provenance += Transformation("{1} as been subtracted to {0}".format(lhs, rhs))
+                # __mul__
+                elif op == "*":
+                    provenance += Transformation("{0} as been multiplied by {1}".format(lhs, rhs))
+                # __mul__
+                elif op == "/":
+                    provenance += Transformation("{0} as been divided by {1}".format(lhs, rhs))
+                    
+                if outputs is None:
+                                            
+                    name = "({0}) {1} ({2})".format(lhs, op, rhs)
+                
+                            
+            if isinstance(result, SkhepNumpyArray):
+                result.name       = name
+                result.provenance = provenance
+            
+        return result
 # -----------------------------------------------------------------------------
 # Add Numpy methods to NumpyDataset in bulk.
 # -----------------------------------------------------------------------------
-def addNumpyMethod(method):
-    def fn(self, name, *args, **kwds):
-        return method.__call__(self.data, *args, **kwds)
-
-    fn.__name__ = method.__name__
-    fn.__doc__ = method.__doc__
-    if sys.version_info[0]==2:  # ugly but works! TODO: find nicer way
-        setattr(NumpyDataset, method.__name__, MethodType(fn, None, NumpyDataset))
-    else:
-        setattr(NumpyDataset, method.__name__, MethodType(fn, NumpyDataset))
-
-try:
-    addNumpyMethod(numpy.ndarray.__add__)
-    addNumpyMethod(numpy.ndarray.__mul__)
-    addNumpyMethod(numpy.ndarray.sum)
-    addNumpyMethod(numpy.ndarray.mean)
-except ImportError:
-    pass
+#def addNumpyMethod(method):
+#    def fn(self, name, *args, **kwds):
+#        return method.__call__(self.data, *args, **kwds)
+#
+#    fn.__name__ = method.__name__
+#    fn.__doc__ = method.__doc__
+#    if sys.version_info[0]==2:  # ugly but works! TODO: find nicer way
+#        setattr(NumpyDataset, method.__name__, MethodType(fn, None, NumpyDataset))
+#    else:
+#        setattr(NumpyDataset, method.__name__, MethodType(fn, NumpyDataset))
+#
+#try:
+#    addNumpyMethod(numpy.ndarray.__add__)
+#    addNumpyMethod(numpy.ndarray.__mul__)
+#    addNumpyMethod(numpy.ndarray.sum)
+#    addNumpyMethod(numpy.ndarray.mean)
+#except ImportError:
+#    pass

--- a/skhep/dataset/selection.py
+++ b/skhep/dataset/selection.py
@@ -1,0 +1,257 @@
+# Licensed under a 3-clause BSD style license, see LICENSE.
+"""
+***********************
+Module for Selection
+***********************
+"""
+
+# -----------------------------------------------------------------------------
+# Import statements
+# -----------------------------------------------------------------------------
+from ..utils.py23 import *
+from ..utils.dependencies import softimport
+
+
+numpy = softimport("numpy")
+pyparsing = softimport("pyparsing")
+
+# -----------------------------------------------------------------------------
+# Selection class
+# -----------------------------------------------------------------------------
+class Selection(object):
+    """
+    Class for dataset selections.
+    """
+    
+    def __init__(self, selection=""):
+        
+        selection = selection.replace( "&&", "&")
+        selection = selection.replace( "||", "|")
+        self._selection = selection
+      
+    @property  
+    def parsed(self):
+        """
+        Return the parsed selection
+        """
+        
+        Optional           = pyparsing.Optional
+        Suppress           = pyparsing.Suppress
+        Literal            = pyparsing.Literal
+        Word               = pyparsing.Word
+        nums               = pyparsing.nums
+        alphas             = pyparsing.alphas 
+        oneOf              = pyparsing.oneOf
+        OneOrMore          = pyparsing.OneOrMore
+        Group              = pyparsing.Group
+        opAssoc            = pyparsing.opAssoc
+        operatorPrecedence = pyparsing.operatorPrecedence
+        ParseResults       = pyparsing.ParseResults
+
+        openpar    = Literal("(")
+        closepar   = Literal(")")
+        comma      = Literal(",")
+        expop      = Literal('^')
+#        signop     = oneOf('+ -')
+        signop     = Literal('-')
+        multop     = oneOf('* /')
+        plusop     = oneOf('+ -')
+        
+        number     = Word(nums+".")
+        variable   = Word(alphas+nums+"."+"-"+"_")
+        operations = operatorPrecedence( number | variable , [("^", 2, opAssoc.RIGHT), (signop, 1, opAssoc.RIGHT), (multop, 2, opAssoc.LEFT), (plusop, 2, opAssoc.LEFT),])
+        min_max    = Group(oneOf("min max") + Suppress(openpar) + Group(OneOrMore( ( operations | variable ) + Suppress(Optional(comma)))) + Suppress(closepar))
+        identifier = min_max | operations | number | variable
+        
+        operator   = oneOf("> < >= <= != ==")
+        subexpr = identifier.setResultsName("lhs") + operator.setResultsName("operator") + identifier.setResultsName("rhs")
+        
+        _and = Literal("&")
+        _or = Literal("|")
+        
+        exp = operatorPrecedence( Group(subexpr), [(_and, 2, opAssoc.LEFT), (_or, 2, opAssoc.LEFT),])
+        
+        return exp.parseString(self._selection)[0]
+        
+    def evaluateselection(self, dataset, operators, _min, _max):
+        """
+        Evaluate the selection for a given dataset, taking operators, min and max functions
+        according to the type of the dataset.
+        """
+                
+        def operation(lhs=None , operator=None, rhs=None):
+            if lhs is None and operator == "-":
+                return -rhs
+            else:
+                return operators[operator] (lhs, rhs)
+                
+        def operand(_operand):
+            #Return instance of the operand
+    
+            if len(_operand) == 1:
+                _operand = _operand[0]
+            elif len(_operand) > 1 and isinstance(_operand, pyparsing.ParseResults):
+
+                #treatment of min/max as operand 
+                if any(m in _operand.asList() for m in ["min","max"]):
+                    if _operand[0] == "min": func = _min
+                    elif _operand[0] == "max": func = _max
+                        
+                    args = []
+                    for a in _operand[1]:
+                        args.append(operand(a))
+                    return func(*args)
+                                            
+                #treatment with arithmetical operations as operand
+                if any(op in _operand.asList() for op in ["-","+","*","/","^"]):
+                    if len(_operand) == 2:
+                        return operation(operator=_operand[0], rhs=operand(_operand[1])) 
+                    elif len(_operand) > 2:                        
+                        return operation(lhs=operand(_operand[0]), operator=_operand[1], rhs=operand(_operand[2:]))                                            
+            
+            if isinstance(_operand, str):
+                     
+                if _operand == "True":
+                    return True
+                elif _operand == "False":
+                    return False
+                try:
+                    float(_operand)
+                except ValueError:
+                    return dataset[_operand]
+                else:
+                    return float(_operand)
+                    
+        def loopselection(parsedsel):
+            #loop inside the selection, to take into account all subterms, and evaluate the selection
+            #from right to left.    
+            
+            suboperations = []
+            bitwiseoperators = []
+
+            for i,s in enumerate(parsedsel):
+                if i % 2 == 0:
+                    if "&" in s.asList() or "|" in s.asList():
+                        suboperations.append(loopselection(s))
+                    else:
+                        lhs = operand(s.lhs)
+                        rhs = operand(s.rhs)
+                        suboperations.append(operation(lhs, s.operator, rhs))
+                else:
+                    bitwiseoperators.append(s)
+                    
+            while len(bitwiseoperators) > 0:
+                index = bitwiseoperators.index(bitwiseoperators[-1])
+                loopedselection = operation( suboperations[index], bitwiseoperators[-1], suboperations[index+1] )
+                bitwiseoperators.pop(); suboperations.pop(); suboperations.pop()
+                suboperations.append(loopedselection)
+
+            return loopedselection
+            
+        if "&" in self.parsed.asList() or "|" in self.parsed.asList():
+            evaluatedselection = loopselection(self.parsed)
+        else:
+            s = self.parsed
+            lhs = operand(s.lhs)
+            rhs = operand(s.rhs)
+            evaluatedselection = operation(lhs, s.operator, rhs)
+        
+        return evaluatedselection
+
+    
+    @property    
+    def numpyselection(self):
+        """
+        Return the selection readable for NumpyDataset
+        """
+        
+        operators = {">": numpy.greater, "<": numpy.less, ">=": numpy.greater_equal, "<=": numpy.less_equal,
+                     "==": numpy.equal, "!=": numpy.not_equal, "&": numpy.bitwise_and, "|": numpy.bitwise_and,
+                     "+": numpy.add, "-": numpy.subtract, "/": numpy.divide, "*": numpy.multiply,
+                     "^": numpy.power}
+        
+        def evaluateufunc(ufunc, *args):
+            if len(args) == 2:
+                return ufunc(*args)
+            else:
+                return ufunc.reduce(args)
+        
+        def _min(*args):
+            ufunc = numpy.minimum
+            return evaluateufunc(ufunc, *args)
+            
+        def _max(*args):
+            ufunc = numpy.minimum
+            return evaluateufunc(ufunc, *args)
+            
+        def selection(numpydataset):
+            # selection as a function of the numpy dataset
+            return self.evaluateselection(numpydataset, operators, _min, _max)
+            
+        return selection
+    
+    @property    
+    def rootselection(self):
+        """
+        Return the selection readable for RootDataset
+        """
+        
+        selection = self._selection.replace("&","&&")
+        selection = selection.replace("|","||")
+        return selection
+                                                
+    def __repr__(self):
+        return self._selection
+        
+    def __and__(self, other):
+        """
+        Return new selection = self and other
+        """
+        
+        if not isinstance(other, Selection):
+            return NotImplemented
+            
+        if "|" in self._selection:
+            lhs = "(" + self._selection + ")"
+        else:
+            lhs = self._selection
+            
+        if "|" in other._selection:
+            rhs = "(" + other._selection + ")"
+        else:
+            rhs = other._selection
+
+        selection = lhs + " & " + rhs
+
+        return Selection(selection)
+        
+    def __or__(self, other):
+        """
+        Return new selection = self or other
+        """
+        
+        if not isinstance(other, Selection):
+            return NotImplemented
+            
+        if "&" in self._selection:
+            lhs = "(" + self._selection + ")"
+        else:
+            lhs = self._selection
+            
+        if "&" in other._selection:
+            rhs = "(" + other._selection + ")"
+        else:
+            rhs = other._selection
+
+        selection = lhs + " | " + rhs
+
+        return Selection(selection)
+        
+        
+        
+        
+        
+
+                    
+            
+                        

--- a/skhep/dataset/selection.py
+++ b/skhep/dataset/selection.py
@@ -46,13 +46,11 @@ class Selection(object):
         Group              = pyparsing.Group
         opAssoc            = pyparsing.opAssoc
         operatorPrecedence = pyparsing.operatorPrecedence
-        ParseResults       = pyparsing.ParseResults
 
         openpar    = Literal("(")
         closepar   = Literal(")")
         comma      = Literal(",")
         expop      = Literal('^')
-#        signop     = oneOf('+ -')
         signop     = Literal('-')
         multop     = oneOf('* /')
         plusop     = oneOf('+ -')
@@ -189,6 +187,14 @@ class Selection(object):
             return self.evaluateselection(numpydataset, operators, _min, _max)
             
         return selection
+        
+    @property    
+    def pandasselection(self):
+        """
+        Return the selection readable for possible PandasDataset
+        """
+        
+        raise NotImplementedError
     
     @property    
     def rootselection(self):

--- a/skhep/utils/provenance.py
+++ b/skhep/utils/provenance.py
@@ -222,12 +222,27 @@ class MultiProvenance(object):
         return self._provenances[i]
         
     def __repr__(self):
-        rep = ""
-        for i,provenance in enumerate(self._provenances):
-            rep += "{0}: {1}".format(i, provenance)
-            if provenance != self._provenances[-1]:
-                rep += " \n"
-        return rep
+        if len(self._provenances) == 1:
+            return repr(self._provenances[0])
+        else:
+            rep = ""
+            for i,provenance in enumerate(self._provenances):
+                rep += "{0}: {1}".format(i, provenance)
+                if provenance != self._provenances[-1]:
+                    rep += " \n"
+            return rep
+            
+    @property
+    def detail(self):
+        if len(self._provenances) == 1:
+            return getattr( self._provenances[0], "detail", "")
+        else:
+            rep = ""
+            for i,provenance in enumerate(self._provenances):
+                rep += "{0}: {1}".format(i, provenance.detail)
+                if provenance != self._provenances[-1]:
+                    rep += " \n"
+            return rep
         
     def __iadd__(self, object):
         if not isinstance( object, ( Provenance , MultiProvenance )):

--- a/skhep/utils/provenance.py
+++ b/skhep/utils/provenance.py
@@ -131,19 +131,9 @@ class FileOrigin(Origin):
     def detail(self):
         return ",".join(json.dumps(x) for x in self.files)
 
-    @property
-    def history(self):
-        return []
-
     def __repr__(self):
         return "<FileOrigin ({0} file{1})>".format(len(self.files),'s' if len(self.files)>1 else '')
         
-    def __add__(self, other):
-        if not isinstance ( other ,  FileOrigin ) : 
-            return NotImplemented
-        else:
-            return FileOrigin(self.detail + other.detail)
-            
 class Transformation(Provenance):
     """
     Declares that the dataset was transformed by some mathematical operation.
@@ -219,7 +209,7 @@ class MultiProvenance(object):
     """
 
     def __init__(self, *args):
-        if not all([isinstance(arg, (Provenance, MultiProvenance )) for arg in args]):
+        if not all(isinstance(arg, (Provenance, MultiProvenance )) for arg in args):
             raise ValueError("Inputs must be Provenance types!")
         if len(args) == 1 and isinstance(args[0], MultiProvenance):
             args = args[0]

--- a/skhep/utils/provenance.py
+++ b/skhep/utils/provenance.py
@@ -164,12 +164,12 @@ class Transformation(Provenance):
             subdetail = ""
             for x in self.args:
                 if isinstance(x, Provenance):
-                    subdetail += ", {}".format(x.detail)
+                    subdetail += ", {0}".format(x.detail)
                 else:
-                    subdetail += ", {}".format(x)
+                    subdetail += ", {0}".format(x)
                 if x == self.args[0]:
                     subdetail = subdetail.replace(", ","")
-            detail += " ({})".format(subdetail)
+            detail += " ({0})".format(subdetail)
         return detail
             
     def __repr__(self):
@@ -191,12 +191,12 @@ class Formatting(Provenance):
             subdetail = ""
             for x in self.args:
                 if isinstance(x, Provenance):
-                    subdetail += ", {}".format(x.detail)
+                    subdetail += ", {0}".format(x.detail)
                 else:
-                    subdetail += ", {}".format(x)
+                    subdetail += ", {0}".format(x)
                 if x == self.args[0]:
                     subdetail = subdetail.replace(", ","")
-            detail += "({})".format(subdetail)
+            detail += "({0})".format(subdetail)
         return detail
     
     def __repr__(self):
@@ -231,7 +231,7 @@ class MultiProvenance(object):
         
     def __iadd__(self, object):
         if not isinstance( object, ( Provenance , MultiProvenance )):
-            raise ValueError("Cannot add a {} to MultiProvenance!".format(type(object)))
+            raise ValueError("Cannot add a {0} to MultiProvenance!".format(type(object)))
         elif isinstance( object, MultiProvenance):
             self._provenances += object._provenances
         else:

--- a/tests/dataset/test_numpydataset.py
+++ b/tests/dataset/test_numpydataset.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from skhep.utils.provenance import ObjectOrigin  # these are not imported automatically
 from skhep.dataset.numpydataset import *
+from skhep.dataset.selection import Selection
 
 
 # -----------------------------------------------------------------------------
@@ -24,11 +25,12 @@ ar = np.array([(1,1),(2,2),(3,3)],dtype=[('x',int), ('y',int)])
 
 def test_constructors():
     ds = NumpyDataset(ar)
+    a = SkhepNumpyArray([1,2,3])
 
 def test_properties():
     ds = NumpyDataset(ar, ObjectOrigin('simple_array'))
     assert type(ds.data) == np.ndarray
-    assert ds.provenance.__repr__() == '<ObjectOrigin>'
+    assert ds.provenance[0].__repr__() == '<ObjectOrigin>'
     assert ds.mutable == True
     assert ds.immutable == False
     assert ds.transient == True
@@ -38,10 +40,56 @@ def test_properties():
 
 def test_methods():
     ds1 = NumpyDataset(ar)
+    assert ds1.__repr__() == "NumpyDataset([(1, 1), (2, 2), (3, 3)],\n      dtype=[('x', '<i8'), ('y', '<i8')])"
+    assert ds1.__str__() == "[(1, 1) (2, 2) (3, 3)]"
     ds1.to_file('npds.npz')
     ds2 = NumpyDataset.from_file('npds.npz')
-    assert ds2.provenance.__repr__() == '<FileOrigin (1 file)>'
+    assert ds2.provenance[0].__repr__() == '<FileOrigin (1 file)>'
     os.remove('npds.npz')
     with pytest.raises(IOError):
         ds = NumpyDataset.from_file('non_existent_file')
     assert ds1['x'].tolist() == [1,2,3]
+    assert ds1.x.tolist() == [1,2,3]
+    assert ds1.x.name == "x"
+    assert ds1.x.provenance[0].detail == repr(ds1)
+    ds1.z = np.ones((3,))
+    assert ds1['z'].tolist() == [1,1,1]
+    assert ds1.z.tolist() == [1,1,1]
+    assert ds1.provenance[-1].__repr__() == "<Transformation(Array z has been created)>"
+    ds1['w'] = np.zeros((3,))
+    assert ds1.provenance[-1].__repr__() == "<Transformation(Array w has been created)>"
+    assert ds1['w'].tolist() == [0,0,0]
+    assert ds1.w.tolist() == [0,0,0]
+    with pytest.raises(ValueError):
+        ds1['h'] = np.ones((4,))
+        ds1.h = np.ones((4,))
+    ds1.z = ds1.w
+    assert ds1.provenance[-1].__repr__() =="<Transformation(Array z as been replaced by w)>"
+    ds1.w = np.array([6,7,8])
+    assert ds1.provenance[-1].__repr__() =="<Transformation(Array w as been replaced by array([6, 7, 8]))>"
+    
+def test_transformations():
+
+    ds1 = NumpyDataset(ar)
+    ds1.r = (ds1.x**2 + ds1.y**2)**0.5
+    ds1.x += 1
+    ds1.provenance[-1] == "<Transformation(1 as been added to x)>"
+    ds1.x *= 2
+    ds1.provenance[-1] == "<x as been multiplied by 2)>"
+    ds1.x -= 3
+    ds1.provenance[-1] == "<Transformation(3 as been subtracted to x)>"
+    ds1.x /= 4
+    ds1.provenance[-1] == "<Transformation(x as been divided by 4)>"
+    
+def test_selections():
+    ds1 = NumpyDataset(ar)
+    sel = Selection("x > 1")
+    ds2 = ds1.select(sel)
+    ds2.provenance[-1] == "<Transformation(Selection, (x > 1), applied)>"
+    assert ds2.__str__() == ds1.select("x > 1").__str__()
+    with pytest.raises(ValueError):
+        ds1.select(ds1.x)
+    ds3 = ds1[ds1.x > 1]
+    ds3.provenance[-1] == "<Transformation(Subsetting dataset: x > 1)>"
+    ds4 = ds1.select(ds1.x > 1)
+    ds4.provenance[-1] == "<Transformation(Subsetting dataset: x > 1)>"

--- a/tests/dataset/test_numpydataset.py
+++ b/tests/dataset/test_numpydataset.py
@@ -63,6 +63,7 @@ def test_methods():
     assert ds1.w.tolist() == [0,0,0]
     with pytest.raises(ValueError):
         ds1.__setitem__('h',np.ones((4,)))
+    with pytest.raises(ValueError):
         ds1.__setitem__('k',"array")
     ds1.z = ds1.w
     assert ds1.provenance[-1].__repr__() =="<Transformation(Array z as been replaced by w)>"
@@ -72,7 +73,6 @@ def test_methods():
 def test_transformations():
 
     ds1 = NumpyDataset(ar)
-    ds1.r = (ds1.x**2 + ds1.y**2)**0.5
     ds1.x += 1
     assert repr(ds1.provenance[-1]) == "<Transformation(1 as been added to x)>"
     ds1.x *= 2
@@ -81,6 +81,7 @@ def test_transformations():
     assert repr(ds1.provenance[-1]) == "<Transformation(3 as been subtracted to x)>"
     ds1.x /= 4
     assert repr(ds1.provenance[-1]) == "<Transformation(x as been divided by 4)>"
+    ds1.r = (ds1.x**2 + ds1.y**2)**0.5
     
 def test_selections():
     ds1 = NumpyDataset(ar)
@@ -88,8 +89,6 @@ def test_selections():
     ds2 = ds1.select(sel)
     ds2.provenance[-1] == "<Transformation(Selection, (x > 1), applied)>"
     assert ds2.__str__() == ds1.select("x > 1").__str__()
-    with pytest.raises(ValueError):
-        ds1.select(ds1.x)
     ds3 = ds1[ds1.x > 1]
     assert repr(ds3.provenance[-1]) == "<Transformation(Subsetting dataset: x > 1)>"
     ds4 = ds1.select(ds1.x > 1)
@@ -97,5 +96,9 @@ def test_selections():
     ds5 = ds1.select("(x > 1) & (y > 1)")
     ds6 = ds1.select("min(x,y) > 1")
     ds7 = ds1.select("max(x,y) > 1")
+    ds8 = ds1.select("( x * y ) > 1")
+    with pytest.raises(ValueError):
+        ds9 = ds1.copy()
+        ds9.select(ds8.x)
 #    dst = ds1.to_tree("DecayTree")
 #    assert repr(dst.provenance[-1]) == "<Formatting to ROOTDataset(DecayTree)>"

--- a/tests/dataset/test_numpydataset.py
+++ b/tests/dataset/test_numpydataset.py
@@ -40,7 +40,7 @@ def test_properties():
 
 def test_methods():
     ds1 = NumpyDataset(ar)
-    assert ds1.__repr__() == "NumpyDataset([(1, 1), (2, 2), (3, 3)],\n      dtype=[('x', '<i8'), ('y', '<i8')])"
+    ds1.__repr__()
     assert ds1.__str__() == "[(1, 1) (2, 2) (3, 3)]"
     ds1.to_file('npds.npz')
     ds2 = NumpyDataset.from_file('npds.npz')
@@ -48,6 +48,7 @@ def test_methods():
     os.remove('npds.npz')
     with pytest.raises(IOError):
         ds = NumpyDataset.from_file('non_existent_file')
+    ds3 = ds1.copy()
     assert ds1['x'].tolist() == [1,2,3]
     assert ds1.x.tolist() == [1,2,3]
     assert ds1.x.name == "x"
@@ -61,8 +62,8 @@ def test_methods():
     assert ds1['w'].tolist() == [0,0,0]
     assert ds1.w.tolist() == [0,0,0]
     with pytest.raises(ValueError):
-        ds1['h'] = np.ones((4,))
-        ds1.h = np.ones((4,))
+        ds1.__setitem__('h',np.ones((4,)))
+        ds1.__setitem__('k',"array")
     ds1.z = ds1.w
     assert ds1.provenance[-1].__repr__() =="<Transformation(Array z as been replaced by w)>"
     ds1.w = np.array([6,7,8])
@@ -73,13 +74,13 @@ def test_transformations():
     ds1 = NumpyDataset(ar)
     ds1.r = (ds1.x**2 + ds1.y**2)**0.5
     ds1.x += 1
-    ds1.provenance[-1] == "<Transformation(1 as been added to x)>"
+    assert repr(ds1.provenance[-1]) == "<Transformation(1 as been added to x)>"
     ds1.x *= 2
-    ds1.provenance[-1] == "<x as been multiplied by 2)>"
+    assert repr(ds1.provenance[-1]) == "<Transformation(x as been multiplied by 2)>"
     ds1.x -= 3
-    ds1.provenance[-1] == "<Transformation(3 as been subtracted to x)>"
+    assert repr(ds1.provenance[-1]) == "<Transformation(3 as been subtracted to x)>"
     ds1.x /= 4
-    ds1.provenance[-1] == "<Transformation(x as been divided by 4)>"
+    assert repr(ds1.provenance[-1]) == "<Transformation(x as been divided by 4)>"
     
 def test_selections():
     ds1 = NumpyDataset(ar)
@@ -90,6 +91,11 @@ def test_selections():
     with pytest.raises(ValueError):
         ds1.select(ds1.x)
     ds3 = ds1[ds1.x > 1]
-    ds3.provenance[-1] == "<Transformation(Subsetting dataset: x > 1)>"
+    assert repr(ds3.provenance[-1]) == "<Transformation(Subsetting dataset: x > 1)>"
     ds4 = ds1.select(ds1.x > 1)
-    ds4.provenance[-1] == "<Transformation(Subsetting dataset: x > 1)>"
+    assert repr(ds4.provenance[-1]) == "<Transformation(Subsetting dataset: x > 1)>"
+    ds5 = ds1.select("(x > 1) & (y > 1)")
+    ds6 = ds1.select("min(x,y) > 1")
+    ds7 = ds1.select("max(x,y) > 1")
+#    dst = ds1.to_tree("DecayTree")
+#    assert repr(dst.provenance[-1]) == "<Formatting to ROOTDataset(DecayTree)>"

--- a/tests/dataset/test_numpydataset.py
+++ b/tests/dataset/test_numpydataset.py
@@ -31,6 +31,7 @@ def test_properties():
     ds = NumpyDataset(ar, ObjectOrigin('simple_array'))
     assert type(ds.data) == np.ndarray
     assert ds.provenance[0].__repr__() == '<ObjectOrigin>'
+    assert ds.provenance.__repr__() == '<ObjectOrigin>'
     assert ds.mutable == True
     assert ds.immutable == False
     assert ds.transient == True
@@ -85,6 +86,7 @@ def test_transformations():
     
 def test_selections():
     ds1 = NumpyDataset(ar)
+    ds1.z = (ds1.x**2 + ds1.y**2)**0.5
     sel = Selection("x > 1")
     ds2 = ds1.select(sel)
     ds2.provenance[-1] == "<Transformation(Selection, (x > 1), applied)>"
@@ -97,8 +99,9 @@ def test_selections():
     ds6 = ds1.select("min(x,y) > 1")
     ds7 = ds1.select("max(x,y) > 1")
     ds8 = ds1.select("( x * y ) > 1")
+    ds9 = ds1.select("max(x,y,z) > 1")
     with pytest.raises(ValueError):
-        ds9 = ds1.copy()
-        ds9.select(ds8.x)
+        ds10 = ds1.copy()
+        ds10.select(ds8.x)
 #    dst = ds1.to_tree("DecayTree")
 #    assert repr(dst.provenance[-1]) == "<Formatting to ROOTDataset(DecayTree)>"

--- a/tests/dataset/test_numpydataset.py
+++ b/tests/dataset/test_numpydataset.py
@@ -66,21 +66,21 @@ def test_methods():
     with pytest.raises(ValueError):
         ds1.__setitem__('k',"array")
     ds1.z = ds1.w
-    assert ds1.provenance[-1].__repr__() =="<Transformation(Array z as been replaced by w)>"
+    assert ds1.provenance[-1].__repr__() =="<Transformation(Array z has been replaced by w)>"
     ds1.w = np.array([6,7,8])
-    assert ds1.provenance[-1].__repr__() =="<Transformation(Array w as been replaced by array([6, 7, 8]))>"
+    assert ds1.provenance[-1].__repr__() =="<Transformation(Array w has been replaced by array([6, 7, 8]))>"
     
 def test_transformations():
 
     ds1 = NumpyDataset(ar)
     ds1.x += 1
-    assert repr(ds1.provenance[-1]) == "<Transformation(1 as been added to x)>"
+    assert repr(ds1.provenance[-1]) == "<Transformation(1 has been added to x)>"
     ds1.x *= 2
-    assert repr(ds1.provenance[-1]) == "<Transformation(x as been multiplied by 2)>"
+    assert repr(ds1.provenance[-1]) == "<Transformation(x has been multiplied by 2)>"
     ds1.x -= 3
-    assert repr(ds1.provenance[-1]) == "<Transformation(3 as been subtracted to x)>"
+    assert repr(ds1.provenance[-1]) == "<Transformation(3 has been subtracted to x)>"
     ds1.x /= 4
-    assert repr(ds1.provenance[-1]) == "<Transformation(x as been divided by 4)>"
+    assert repr(ds1.provenance[-1]) == "<Transformation(x has been divided by 4)>"
     ds1.r = (ds1.x**2 + ds1.y**2)**0.5
     
 def test_selections():

--- a/tests/dataset/test_rootdataset.py
+++ b/tests/dataset/test_rootdataset.py
@@ -18,6 +18,7 @@ ROOT = pytest.importorskip('ROOT')
 from ROOT import gROOT, TTree, TChain, TFile, AddressOf
 
 from skhep.dataset.rootdataset import *
+from skhep.dataset.selection import Selection
 
 # -----------------------------------------------------------------------------
 # Actual tests
@@ -108,6 +109,17 @@ def test_methods():
     del ds4, ds5, ds6
     os.remove('new_tree.root')
     os.remove('new_chain.root')
+    
+def test_selections():
+    tree = create_simple_tree(200)
+    sel1 = Selection("x > 1")
+    sel2 = Selection("y > 1")
+    sel3 = sel1 | sel2
+    sel4 = sel1 & sel2
+    tree_sel = tree.CopyTree(sel3.rootselection)
+    assert tree_sel.GetEntries() < tree.GetEntries()
+    tree_sel = tree.CopyTree(sel4.rootselection)
+    assert tree_sel.GetEntries() < tree.GetEntries()
 
 os.remove('tree1.root')
 os.remove('tree2.root')

--- a/tests/dataset/test_selection.py
+++ b/tests/dataset/test_selection.py
@@ -24,7 +24,7 @@ from skhep.dataset.selection import Selection
 def test_constructors():	
 	s = Selection()
 	
-def test_methods():
+def test_methods():	
 	s1 = Selection("x > 1")
 	assert s1.__repr__() == "x > 1"
 	assert s1.parsed.lhs == "x"
@@ -54,5 +54,8 @@ def test_methods():
 	assert s6.__repr__() == "z <= x | (x > 1 & y^2 < 2)"
 	s7 = s5 & s4
 	assert s7.__repr__() == "z <= x & x > 1 & y^2 < 2"
+	s8 = Selection("-x < 1")
+	s9 = ( s4 | s5 ) & s6
+
 	
 	

--- a/tests/dataset/test_selection.py
+++ b/tests/dataset/test_selection.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# Licensed under a 3-clause BSD style license, see LICENSE.
+"""
+Tests for the skhep.dataset.selection module.
+"""
+
+# -----------------------------------------------------------------------------
+# Import statements
+# -----------------------------------------------------------------------------
+import pytest
+import os
+
+import numpy as np
+
+from skhep.utils.provenance import ObjectOrigin  # these are not imported automatically
+from skhep.dataset.numpydataset import *
+from skhep.dataset.selection import Selection
+
+
+# -----------------------------------------------------------------------------
+# Actual tests
+# -----------------------------------------------------------------------------
+
+def test_constructors():	
+	s = Selection()
+	
+def test_methods():
+	s1 = Selection("x > 1")
+	assert s1.__repr__() == "x > 1"
+	assert s1.parsed.lhs == "x"
+	assert s1.parsed.operator == ">"
+	assert s1.parsed.rhs == "1"
+	s2 = Selection("y^2 < 2")
+	assert s2.__repr__() == "y^2 < 2"
+	assert s2.parsed.lhs.asList() == ['y', '^', '2']
+	assert s2.parsed.operator == "<"
+	assert s2.parsed.rhs == "2"
+	s3 = s1 | s2
+	assert s3.__repr__() == "x > 1 | y^2 < 2"
+	assert s3.parsed[0].asList() == s1.parsed.asList()
+	assert s3.parsed[1] == "|"
+	assert s3.parsed[2].asList() == s2.parsed.asList()
+	s4 = s1 & s2
+	assert s4.__repr__() == "x > 1 & y^2 < 2"
+	assert s4.parsed[1] == "&"
+	s5 = Selection("z <= x")
+	assert s5.__repr__() == "z <= x"
+	assert s5.parsed.lhs == "z"
+	assert s5.parsed.operator == "<="
+	assert s5.parsed.rhs == "x"
+	s6 = s5 | s4
+	assert s6.__repr__() == "z <= x | (x > 1 & y^2 < 2)"
+	s7 = s5 & s4
+	assert s7.__repr__() == "z <= x & x > 1 & y^2 < 2"
+	

--- a/tests/dataset/test_selection.py
+++ b/tests/dataset/test_selection.py
@@ -37,6 +37,7 @@ def test_methods():
 	assert s2.parsed.rhs == "2"
 	s3 = s1 | s2
 	assert s3.__repr__() == "x > 1 | y^2 < 2"
+	s1 & s3
 	assert s3.parsed[0].asList() == s1.parsed.asList()
 	assert s3.parsed[1] == "|"
 	assert s3.parsed[2].asList() == s2.parsed.asList()
@@ -48,8 +49,10 @@ def test_methods():
 	assert s5.parsed.lhs == "z"
 	assert s5.parsed.operator == "<="
 	assert s5.parsed.rhs == "x"
+	s6 = s4 | s5
 	s6 = s5 | s4
 	assert s6.__repr__() == "z <= x | (x > 1 & y^2 < 2)"
 	s7 = s5 & s4
 	assert s7.__repr__() == "z <= x & x > 1 & y^2 < 2"
+	
 	

--- a/tests/utils/test_provenance.py
+++ b/tests/utils/test_provenance.py
@@ -10,7 +10,7 @@ Tests for the skhep.utils.provenance module.
 import pytest
 
 from skhep.utils import *
-from skhep.utils.provenance import Provenance, Origin  # these are not imported automatically
+from skhep.utils.provenance import Provenance, Origin, MultiProvenance  # these are not imported automatically
 
 
 # -----------------------------------------------------------------------------
@@ -52,8 +52,29 @@ def test_Transformation():
         Transformation.__init__()
     transf = Transformation('all elms * 2')
     assert transf.__repr__() == '<Transformation(all elms * 2)>'
-    assert transf.detail == 'all elms * 2 (,)'
+    assert transf.detail == 'all elms * 2'
 
 def test_Formatting():
     with pytest.raises(TypeError):
         Formatting.__init__()
+    forma = Formatting('ROOTDataset', 'DecayTree')
+    assert forma.__repr__() == '<Formatting to ROOTDataset(DecayTree)>'
+    assert forma.detail == 'ROOTDataset(DecayTree)'
+    
+def test_MultiProvenance():
+    with pytest.raises(TypeError):
+        MultiProvenance.__init__()
+        
+    prov1 = FileOrigin('file.root')
+    multip = MultiProvenance(prov1)
+    assert multip[0].__repr__() == '<FileOrigin (1 file)>'
+    assert multip[0].detail == '"file.root"'
+    transf = Transformation('all elms * 2')
+    multip += transf
+    assert multip[1].__repr__() == '<Transformation(all elms * 2)>'
+    assert multip[1].detail == 'all elms * 2'
+    forma = Formatting('ROOTDataset', 'DecayTree')
+    multip1 = multip.copy() + MultiProvenance(forma)
+    assert multip1[2].__repr__() == '<Formatting to ROOTDataset(DecayTree)>'
+    assert multip1[2].detail == 'ROOTDataset(DecayTree)'
+    assert multip1.__repr__() == "0: {0} \n1: {1} \n2: {2}".format(prov1, transf, forma)

--- a/tests/utils/test_provenance.py
+++ b/tests/utils/test_provenance.py
@@ -25,6 +25,8 @@ def test_base_classes():
         Origin.__init__()
     with pytest.raises(SkhepTypeError):
         Provenance()
+    with pytest.raises(SkhepTypeError):
+        Origin()
 
 def test_ObjectOrigin():
     with pytest.raises(TypeError):
@@ -56,6 +58,8 @@ def test_Transformation():
     transf = Transformation('all elms * 2')
     assert transf.__repr__() == '<Transformation(all elms * 2)>'
     assert transf.detail == 'all elms * 2'
+    transf1 = Transformation('all elms * 2', "detail1", "detail2", transf)
+    transf1.detail
 
 def test_Formatting():
     with pytest.raises(TypeError):
@@ -63,6 +67,7 @@ def test_Formatting():
     forma = Formatting('ROOTDataset', 'DecayTree')
     assert forma.__repr__() == '<Formatting to ROOTDataset(DecayTree)>'
     assert forma.detail == 'ROOTDataset(DecayTree)'
+    forma1 = Formatting('ROOTDataset', 'DecayTree', "detail1", forma)
     
 def test_MultiProvenance():
     with pytest.raises(TypeError):
@@ -85,3 +90,4 @@ def test_MultiProvenance():
     assert multip1[2].__repr__() == '<Formatting to ROOTDataset(DecayTree)>'
     assert multip1[2].detail == 'ROOTDataset(DecayTree)'
     assert multip1.__repr__() == "0: {0} \n1: {1} \n2: {2}".format(prov1, transf, forma)
+    multip2 = MultiProvenance(multip1)

--- a/tests/utils/test_provenance.py
+++ b/tests/utils/test_provenance.py
@@ -11,6 +11,7 @@ import pytest
 
 from skhep.utils import *
 from skhep.utils.provenance import Provenance, Origin, MultiProvenance  # these are not imported automatically
+from skhep.utils.exceptions import *
 
 
 # -----------------------------------------------------------------------------
@@ -22,6 +23,8 @@ def test_base_classes():
         Provenance.__init__()
     with pytest.raises(TypeError):
         Origin.__init__()
+    with pytest.raises(SkhepTypeError):
+        Provenance()
 
 def test_ObjectOrigin():
     with pytest.raises(TypeError):
@@ -64,6 +67,10 @@ def test_Formatting():
 def test_MultiProvenance():
     with pytest.raises(TypeError):
         MultiProvenance.__init__()
+    with pytest.raises(ValueError):
+        MultiProvenance("provenance")
+    with pytest.raises(ValueError):
+        MultiProvenance.__iadd__(MultiProvenance(),"provenance")
         
     prov1 = FileOrigin('file.root')
     multip = MultiProvenance(prov1)

--- a/tests/utils/test_provenance.py
+++ b/tests/utils/test_provenance.py
@@ -81,6 +81,7 @@ def test_MultiProvenance():
     multip = MultiProvenance(prov1)
     assert multip[0].__repr__() == '<FileOrigin (1 file)>'
     assert multip[0].detail == '"file.root"'
+    assert multip.detail == '"file.root"'
     transf = Transformation('all elms * 2')
     multip += transf
     assert multip[1].__repr__() == '<Transformation(all elms * 2)>'


### PR DESCRIPTION
Hi. 

Following issue #54. I created a class MultiProvenance which is basically a container of Provenances. Every dataset should have one MultiProvenance instance which collects history of Origin/....Transformations.
The representation of a MultiProvenance is as follow:

`MP = MultiProvenance(ObjectOrigin("origin"))`
`MP += Transformation("transformation")`
`MP += Formatting("format")`
`print MP:`

`0: <ObjectOrigin>`
`1: <Transformation(transformation)>`
`2: <Formatting to format>`

Then one can access to a given provenance like this:

`print MP[1]`: <Transformation(transformation)>
`print MP[0].detail`: origin
...

From this I decided to go ahead and implement this and other stuffs in NumpyDataset.
So for example if we have:
`ar = np.array([(1,1),(2,2),(3,3)],dtype=[('x',int), ('y',int)])
ds = NumpyDataset(ar)`

`print ds.provenance`: 0: <ObjectOrigin

I thought that it would be very convenient to put the observables/variables as property attributes of the instance of NumpyDataset. Like this`print ds1.x`: [1 2 3] and also `print ds1['x']`: [1 2 3].

What I think is awesome for an analysis point of view is to add variables in the dataset as easy as possible. What is possible to do here is for instance `ds1.z = np.zeros((3,))` (equivalently `ds1["z"] = np.zeros(ds.shape)`) or even something like this `ds1.r = (ds1.x**2 + ds1.y**2)**0.5`.
Now if you check the provenance you have:

`print ds.provenance[-1]`: <Transformation(Array z has been created)>

I've also implemented a way to add history of operations on variables/observables of the dataset. The way I found to do that is to create a np.ndarray subclass called "SkhepNumpyArray" which has name and provenance (MultiProvenance) attributes. I've overriden `__array_ufunc__` to add any transformation to the provenance attribute. The information from provenance of the variable are then brought back to the dataset. An example:

`print repr(ds.x)`: SkhepNumpyArray([1, 2, 3])
`print ds.x.name`: x
`print ds.x.provenance`: 0: <ObjectOrigin>
`print ds.x.provenance[0].detail `: NumpyDataset([(1, 1), (2, 2), (3, 3)],\n      dtype=[('x', '<i8'), ('y', '<i8')])

`ds.x += 1`
`print ds.provenance[-1]`: <Transformation(1 as been added to x)>
`ds.y /= 2`
`print ds.provenance[-1]`: <Transformation(y as been divided by 2)>

Other things you can do:
`a = ds.x + ds.y; print a.name`: x + y
`b = ds.x > ds.y; print a.name`: x > y

I guess I've shown the spirit of it. What do you think?

I went further introducing a Selection framework in order to give for example selection "à la ROOT" to NumpyDataset.
`from .dataset.selection import Selection`
`ds = NumpyDataset(ar)`
`sel = Selection("x > 1")`
`ds1 = ds.select(sel)`
`print ds1.provenance[-1]`:  <Transformation(Selection, (x > 1), applied)>

`print repr(ds1)`: "NumpyDataset([(2, 2), (3, 3)],\n      dtype=[('x', '<i8'), ('y', '<i8')])"
 
It is possible to combine selection with '|' or '&':
`sel1 = Selection("x > 1")`
` sel2 = Selection("y < 2")`
`print sel1 | sel2`: x > 1 | y < 2
`print sel1 & sel2`: x > 1 & y < 2

I've learned how to use pyparsing and to parse the input string of `Selection` and you can give selection like this: `sel = Selection( "(max( x, y ) > 1) | (x + y)^2  <=  2)" )`
I've checked this is working, but I've might have missed some cases...

Happy new year. Matt