### PR TITLE
SkhepNumpyArrray fix of 'at' method for ufunc. Better filling of histbook histograms from NumpyDataset.

### DIFF
--- a/skhep/dataset/numpydataset.py
+++ b/skhep/dataset/numpydataset.py
@@ -409,7 +409,6 @@ class SkhepNumpyArray(numpy.ndarray):
         """Sets the name of the variable inside the SkhepNumpyArray."""
         self._name = name
         
-        
     @inheritdoc(numpy.ndarray)   
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         args = []

--- a/skhep/dataset/numpydataset.py
+++ b/skhep/dataset/numpydataset.py
@@ -124,6 +124,12 @@ class NumpyDataset(FromFiles, ToFiles, NewROOT, Dataset):
       of the stored NumPy array.
       """
       return [var for var in self.data.dtype.names]
+      
+    def keys(self):
+      """
+      Get the list of keys in the NumpyDataset, same as 'variables'
+      """
+      return [var for var in self.data.dtype.names]
                               
     @staticmethod
     def isrecarray(data):

--- a/skhep/dataset/numpydataset.py
+++ b/skhep/dataset/numpydataset.py
@@ -17,7 +17,7 @@ Note: usage of course requires that NumPy is installed.
 # -----------------------------------------------------------------------------
 # Import statements
 # -----------------------------------------------------------------------------
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import sys
 from types import MethodType
@@ -93,7 +93,7 @@ class NumpyDataset(FromFiles, ToFiles, NewROOT, Dataset):
           
           nbefore    = self.nevents 
           nafter     = len(data)
-          efficiency = float( nafter / nbefore )
+          efficiency = nafter / nbefore
           error      = (( efficiency * ( 1. - efficiency ) ) / nbefore ) ** 0.5
           
           tr_name    = "Selection, {0}, applied".format(selection)

--- a/tests/dataset/test_numpydataset.py
+++ b/tests/dataset/test_numpydataset.py
@@ -8,6 +8,7 @@ Tests for the skhep.dataset.numpydataset module.
 # Import statements
 # -----------------------------------------------------------------------------
 import pytest
+from pytest import approx
 import os
 
 import numpy as np
@@ -43,6 +44,13 @@ def test_methods():
     ds1 = NumpyDataset(ar)
     ds1.__repr__()
     assert ds1.__str__() == "[(1, 1) (2, 2) (3, 3)]"
+    
+    assert ds1.nentries == 3
+    assert ds1.nevents  == 3
+    
+    assert ds1.variables == ["x", "y"]
+    assert ds1.keys()    == ["x", "y"]
+
     ds1.to_file('npds.npz')
     ds2 = NumpyDataset.from_file('npds.npz')
     assert ds2.provenance[0].__repr__() == '<FileOrigin (1 file)>'
@@ -50,26 +58,32 @@ def test_methods():
     with pytest.raises(IOError):
         ds = NumpyDataset.from_file('non_existent_file')
     ds3 = ds1.copy()
+    
     assert ds1['x'].tolist() == [1,2,3]
     assert ds1.x.tolist() == [1,2,3]
     assert ds1.x.name == "x"
     assert ds1.x.provenance[0].detail == repr(ds1)
+    
     ds1.z = np.ones((3,))
     assert ds1['z'].tolist() == [1,1,1]
     assert ds1.z.tolist() == [1,1,1]
     assert ds1.provenance[-1].__repr__() == "<Transformation(Array z has been created)>"
+    
     ds1['w'] = np.zeros((3,))
     assert ds1.provenance[-1].__repr__() == "<Transformation(Array w has been created)>"
     assert ds1['w'].tolist() == [0,0,0]
     assert ds1.w.tolist() == [0,0,0]
+    
     with pytest.raises(ValueError):
         ds1.__setitem__('h',np.ones((4,)))
     with pytest.raises(ValueError):
         ds1.__setitem__('k',"array")
+        
     ds1.z = ds1.w
     assert ds1.provenance[-1].__repr__() =="<Transformation(Array z has been replaced by w)>"
     ds1.w = np.array([6,7,8])
     assert ds1.provenance[-1].__repr__() =="<Transformation(Array w has been replaced by array([6, 7, 8]))>"
+    
     
 def test_transformations():
 
@@ -84,15 +98,35 @@ def test_transformations():
     assert repr(ds1.provenance[-1]) == "<Transformation(x has been divided by 4)>"
     ds1.r = (ds1.x**2 + ds1.y**2)**0.5
     ds1.expx = np.exp(ds1.x)
-
     
+def test_operations():
+    
+    a = SkhepNumpyArray([1,2,3,4], name = "a")
+    b = SkhepNumpyArray([0,1,2,3], name = "b")
+    np.add.at(a, b, 1)
+    assert a.all() == SkhepNumpyArray([2, 3, 4, 5]).all()
+    
+    c = np.exp(a)
+    print(c[0])
+    assert c[0] == approx(np.exp(2))
+    assert c.provenance[-1].detail == "exp( a )"
+
 def test_selections():
+    
+    ar = np.array([(1,1),(2,2),(3,3)],dtype=[('x',int), ('y',int)])
+    
     ds1 = NumpyDataset(ar)
     ds1.z = (ds1.x**2 + ds1.y**2)**0.5
+    
+    
     sel = Selection("x > 1")
     ds2 = ds1.select(sel)
     ds2.provenance[-1] == "<Transformation(Selection, (x > 1), applied)>"
     assert ds2.__str__() == ds1.select("x > 1").__str__()
+    
+    assert ds2.provenance[-1].detail == ("Selection, x > 1, applied (#events before = 3, "
+                                         + "#events after = 2, Efficiency = 66.6667 +/- 27.2166 %)")
+    
     ds3 = ds1[ds1.x > 1]
     a = ds1.x > 1
     print(ds3.provenance[-1])
@@ -108,4 +142,4 @@ def test_selections():
         ds10 = ds1.copy()
         ds10.select(ds8.x)
 #    dst = ds1.to_tree("DecayTree")
-#    assert repr(dst.provenance[-1]) == "<Formatting to ROOTDataset(DecayTree)>"
+#    assert repr(dst.provenance[-1]) == "<Formatting to ROOTDataset(DecayTree)>


### PR DESCRIPTION
Hi,

This fix is to make an easier filling of variables from a NumpyDataset into **histbook** histograms.

Indeed if you remember my [slides](https://indico.cern.ch/event/694818/contributions/2986392/attachments/1683028/2704704/pyhep-pres.pdf) at PyHEP page 10 for instance  I had to convert the variable M, SkhepNumpyArray, to a regular array because of two issues from:

- __array_finalize__

- __array_ufunc__

which are now fixed.

Additionnaly one can now do thanks to the new `keys` method in NumpyDataset.

```python
zmumu_dataset = NumpyDataset(zmumu.arrays(["px1","px2","py1","py2","M"])) 
histogram = Hist(bin("M", 50, 0, 125))
histogram.fill(**zmumu_dataset)
```

Efficiencies have been added to Transformation details in NumpyDataset selections as well.

