### PR TITLE
fix in Selection __init__ to remove ROOT '&&' and  '||' in the input string

### DIFF
--- a/skhep/dataset/selection.py
+++ b/skhep/dataset/selection.py
@@ -30,9 +30,9 @@ class Selection(object):
         selection: a string.
         """
         
-        sel = selection.replace("&&","&")
-        sel = selection.replace("||","|")
-        self._selection = sel
+        selection = selection.replace("&&","&")
+        selection = selection.replace("||","|")
+        self._selection = selection
 
 
     @property  


### PR DESCRIPTION
@eduardo-rodrigues  fix for #63 