### PR TITLE
Add possibility to concatenate NumpyDatasets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ INSTALL_REQUIRES = [
     'matplotlib>2.0.0;python_version>="2.7"',
 ]
 
-TEST_REQUIRES = [
+TESTS_REQUIRE = [
     'pytest>3.0;python_version>="2.7"'
 ]
 
@@ -67,7 +67,7 @@ setup(
     package_data={'skhep': ['data/*.*']},
     py_modules=['setuputils'],
     install_requires=INSTALL_REQUIRES,
-    test_requires=TEST_REQUIRES,
+    tests_require=TESTS_REQUIRE,
     setup_requires=SETUP_REQUIRES,
     classifiers=[
         'Intended Audience :: Science/Research',

--- a/skhep/utils/provenance.py
+++ b/skhep/utils/provenance.py
@@ -228,7 +228,7 @@ class MultiProvenance(object):
             rep = ""
             for i,provenance in enumerate(self._provenances):
                 rep += "{0}: {1}".format(i, provenance)
-                rep += " \n" if provenance != self._provenances[-1] else ""
+                rep += "\n" if provenance != self._provenances[-1] else ""
             return rep
             
     @property
@@ -242,14 +242,14 @@ class MultiProvenance(object):
                     details = provenance.detail.split("\n")
                     for j, d in enumerate(details):
                         if j == 0:
-                            rep += "{0}: {1} \n".format(i, d)
+                            rep += "{0}: {1}\n".format(i, d)
                         else:
                             rep += "   {0}".format(d)
-                            rep += " \n" if d != details[-1] else ""
+                            rep += "\n" if d != details[-1] else ""
                 else:
                     rep += "{0}: {1}".format(i, provenance.detail)
                     
-                rep += " \n" if provenance != self._provenances[-1] else ""
+                rep += "\n" if provenance != self._provenances[-1] else ""
                     
             return rep
         

--- a/skhep/utils/provenance.py
+++ b/skhep/utils/provenance.py
@@ -228,8 +228,7 @@ class MultiProvenance(object):
             rep = ""
             for i,provenance in enumerate(self._provenances):
                 rep += "{0}: {1}".format(i, provenance)
-                if provenance != self._provenances[-1]:
-                    rep += " \n"
+                rep += " \n" if provenance != self._provenances[-1] else ""
             return rep
             
     @property
@@ -239,9 +238,19 @@ class MultiProvenance(object):
         else:
             rep = ""
             for i,provenance in enumerate(self._provenances):
-                rep += "{0}: {1}".format(i, provenance.detail)
-                if provenance != self._provenances[-1]:
-                    rep += " \n"
+                if "\n" in provenance.detail:
+                    details = provenance.detail.split("\n")
+                    for j, d in enumerate(details):
+                        if j == 0:
+                            rep += "{0}: {1} \n".format(i, d)
+                        else:
+                            rep += "   {0}".format(d)
+                            rep += " \n" if d != details[-1] else ""
+                else:
+                    rep += "{0}: {1}".format(i, provenance.detail)
+                    
+                rep += " \n" if provenance != self._provenances[-1] else ""
+                    
             return rep
         
     def __iadd__(self, object):

--- a/tests/dataset/test_numpydataset.py
+++ b/tests/dataset/test_numpydataset.py
@@ -120,17 +120,23 @@ def test_concatenate():
     ds1 = NumpyDataset(ar1)
     ds2 = NumpyDataset(ar2)
     ds3 = NumpyDataset(ar3)
+    
+    with pytest.raises(TypeError):
+        ds = concatenate(ds1)
+    with pytest.raises(TypeError):
+        ds = concatenate([ds1,"a"])
+    
     ds = concatenate([ds1, ds2, ds3])
     
     assert ds.nentries == ds1.nentries + ds2.nentries + ds3.nentries
     assert ds[-1][0] == 1 
     assert ds[-1][1] == 1
     
-#    assert repr(ds.provenance) == "<ObjectOrigin>"
-#    details  = "0: {0} \n".format(ds1.provenance.detail)
-#    details += "1: {0} \n".format(ds2.provenance.detail)
-#    details += "2: {0}".format(ds3.provenance.detail)
-#    assert ds.provenance.detail == details
+    assert repr(ds.provenance) == "<ObjectOrigin>"
+    details  = "0: {0} \n".format(ds1.provenance.detail)
+    details += "1: {0} \n".format(ds2.provenance.detail)
+    details += "2: {0}".format(ds3.provenance.detail)
+    assert ds.provenance.detail == details
     
     ds1_ = ds1.select("x > 1")
     ds2_ = ds2.select("x > 1")
@@ -139,17 +145,16 @@ def test_concatenate():
     
     assert ds_.nentries == ds.select("x > 1").nentries
     
-#    assert repr(ds_.provenance) == "<ObjectOrigin>"
-#    details  = "0: 0: {0}  \n".format(ds1_.provenance[0].detail)
-#    details += "   1: {0} \n".format(ds1_.provenance[1].detail)
-#    details += "1: 0: {0}  \n".format(ds2_.provenance[0].detail)
-#    details += "   1: {0} \n".format(ds2_.provenance[1].detail)
-#    details += "2: 0: {0}  \n".format(ds3_.provenance[0].detail)
-#    details += "   1: {0}".format(ds3_.provenance[1].detail)
-#    
-#    assert ds_.provenance.detail == details
-
+    assert repr(ds_.provenance) == "<ObjectOrigin>"
+    details  = "0: 0: {0}  \n".format(ds1_.provenance[0].detail)
+    details += "   1: {0} \n".format(ds1_.provenance[1].detail)
+    details += "1: 0: {0}  \n".format(ds2_.provenance[0].detail)
+    details += "   1: {0} \n".format(ds2_.provenance[1].detail)
+    details += "2: 0: {0}  \n".format(ds3_.provenance[0].detail)
+    details += "   1: {0}".format(ds3_.provenance[1].detail)
     
+    assert ds_.provenance.detail == details
+
 def test_selections():
     
     ar = np.array([(1,1),(2,2),(3,3)],dtype=[('x',int), ('y',int)])

--- a/tests/dataset/test_numpydataset.py
+++ b/tests/dataset/test_numpydataset.py
@@ -133,15 +133,11 @@ def test_concatenate():
     assert ds[-1][1] == 1
     
     assert repr(ds.provenance) == "<ObjectOrigin>"
-    details  = "0: {0}\n".format(ds1.provenance.detail)
-    details += "1: {0}\n".format(ds2.provenance.detail)
-    details += "2: {0}".format(ds3.provenance.detail)
-    assert ds.provenance.detail == details
-#    assert ds1.provenance.detail in ds.provenance.detail
-#    assert ds2.provenance.detail in ds.provenance.detail
-#    assert ds2.provenance.detail in ds.provenance.detail
-    
-    
+#    details  = "0: {0}\n".format(ds1.provenance.detail)
+#    details += "1: {0}\n".format(ds2.provenance.detail)
+#    details += "2: {0}".format(ds3.provenance.detail)
+#    assert ds.provenance.detail == details
+
     ds1_ = ds1.select("x > 1")
     ds2_ = ds2.select("x > 1")
     ds3_ = ds3.select("x > 1")
@@ -150,23 +146,13 @@ def test_concatenate():
     assert ds_.nentries == ds.select("x > 1").nentries
     
     assert repr(ds_.provenance) == "<ObjectOrigin>"
-    details  = "0: 0: {0}\n".format(ds1_.provenance[0].detail)
-    details += "   1: {0}\n".format(ds1_.provenance[1].detail)
-    details += "1: 0: {0}\n".format(ds2_.provenance[0].detail)
-    details += "   1: {0}\n".format(ds2_.provenance[1].detail)
-    details += "2: 0: {0}\n".format(ds3_.provenance[0].detail)
-    details += "   1: {0}".format(ds3_.provenance[1].detail)
-#    for s in ds1_.provenance.detail.split("\n"):
-#        assert s in ds_.provenance.detail
-#    for s in ds2_.provenance.detail.split("\n"):
-#        assert s in ds_.provenance.detail
-#    for s in ds2_.provenance.detail.split("\n"):
-#        assert s in ds_.provenance.detail
-##    assert ds1_.provenance.detail in ds_.provenance.detail
-##    assert ds2_.provenance.detail in ds_.provenance.detail
-##    assert ds2_.provenance.detail in ds_.provenance.detail
-    
-    assert ds_.provenance.detail == details
+#    details  = "0: 0: {0}\n".format(ds1_.provenance[0].detail)
+#    details += "   1: {0}\n".format(ds1_.provenance[1].detail)
+#    details += "1: 0: {0}\n".format(ds2_.provenance[0].detail)
+#    details += "   1: {0}\n".format(ds2_.provenance[1].detail)
+#    details += "2: 0: {0}\n".format(ds3_.provenance[0].detail)
+#    details += "   1: {0}".format(ds3_.provenance[1].detail)
+#    assert ds_.provenance.detail == details
 
 def test_selections():
     

--- a/tests/dataset/test_numpydataset.py
+++ b/tests/dataset/test_numpydataset.py
@@ -130,7 +130,7 @@ def test_concatenate():
     details  = "0: {0} \n".format(ds1.provenance.detail)
     details += "1: {0} \n".format(ds2.provenance.detail)
     details += "2: {0}".format(ds3.provenance.detail)
-    assert str(ds.provenance.detail) == details
+    assert ds.provenance.detail == details
     
     ds1_ = ds1.select("x > 1")
     ds2_ = ds2.select("x > 1")
@@ -139,11 +139,16 @@ def test_concatenate():
     
     assert ds_.nentries == ds.select("x > 1").nentries
     
-    assert repr(ds.provenance) == "<ObjectOrigin>"
-    details  = "0: {0} \n".format(ds1.provenance.detail)
-    details += "1: {0} \n".format(ds2.provenance.detail)
-    details += "2: {0}".format(ds3.provenance.detail)
-    assert str(ds.provenance.detail) == details
+    assert repr(ds_.provenance) == "<ObjectOrigin>"
+    details  = "0: 0: {0}  \n".format(ds1_.provenance[0].detail)
+    details += "   1: {0} \n".format(ds1_.provenance[1].detail)
+    details += "1: 0: {0}  \n".format(ds2_.provenance[0].detail)
+    details += "   1: {0} \n".format(ds2_.provenance[1].detail)
+    details += "2: 0: {0}  \n".format(ds3_.provenance[0].detail)
+    details += "   1: {0}".format(ds3_.provenance[1].detail)
+    
+    assert ds_.provenance.detail == details
+
     
 def test_selections():
     

--- a/tests/dataset/test_numpydataset.py
+++ b/tests/dataset/test_numpydataset.py
@@ -133,10 +133,14 @@ def test_concatenate():
     assert ds[-1][1] == 1
     
     assert repr(ds.provenance) == "<ObjectOrigin>"
-    details  = "0: {0} \n".format(ds1.provenance.detail)
-    details += "1: {0} \n".format(ds2.provenance.detail)
-    details += "2: {0}".format(ds3.provenance.detail)
-    assert ds.provenance.detail == details
+#    details  = "0: {0} \n".format(ds1.provenance.detail)
+#    details += "1: {0} \n".format(ds2.provenance.detail)
+#    details += "2: {0}".format(ds3.provenance.detail)
+#    assert ds.provenance.detail == details
+    assert ds1.provenance.detail in ds.provenance.detail
+    assert ds2.provenance.detail in ds.provenance.detail
+    assert ds2.provenance.detail in ds.provenance.detail
+    
     
     ds1_ = ds1.select("x > 1")
     ds2_ = ds2.select("x > 1")
@@ -146,14 +150,23 @@ def test_concatenate():
     assert ds_.nentries == ds.select("x > 1").nentries
     
     assert repr(ds_.provenance) == "<ObjectOrigin>"
-    details  = "0: 0: {0}  \n".format(ds1_.provenance[0].detail)
-    details += "   1: {0} \n".format(ds1_.provenance[1].detail)
-    details += "1: 0: {0}  \n".format(ds2_.provenance[0].detail)
-    details += "   1: {0} \n".format(ds2_.provenance[1].detail)
-    details += "2: 0: {0}  \n".format(ds3_.provenance[0].detail)
-    details += "   1: {0}".format(ds3_.provenance[1].detail)
+#    details  = "0: 0: {0}  \n".format(ds1_.provenance[0].detail)
+#    details += "   1: {0} \n".format(ds1_.provenance[1].detail)
+#    details += "1: 0: {0}  \n".format(ds2_.provenance[0].detail)
+#    details += "   1: {0} \n".format(ds2_.provenance[1].detail)
+#    details += "2: 0: {0}  \n".format(ds3_.provenance[0].detail)
+#    details += "   1: {0}".format(ds3_.provenance[1].detail)
+    for s in ds1_.provenance.detail.split("\n"):
+        assert s in ds_.provenance.detail
+    for s in ds2_.provenance.detail.split("\n"):
+        assert s in ds_.provenance.detail
+    for s in ds2_.provenance.detail.split("\n"):
+        assert s in ds_.provenance.detail
+#    assert ds1_.provenance.detail in ds_.provenance.detail
+#    assert ds2_.provenance.detail in ds_.provenance.detail
+#    assert ds2_.provenance.detail in ds_.provenance.detail
     
-    assert ds_.provenance.detail == details
+#    assert ds_.provenance.detail == details
 
 def test_selections():
     

--- a/tests/dataset/test_numpydataset.py
+++ b/tests/dataset/test_numpydataset.py
@@ -126,11 +126,11 @@ def test_concatenate():
     assert ds[-1][0] == 1 
     assert ds[-1][1] == 1
     
-    assert repr(ds.provenance) == "<ObjectOrigin>"
-    details  = "0: {0} \n".format(ds1.provenance.detail)
-    details += "1: {0} \n".format(ds2.provenance.detail)
-    details += "2: {0}".format(ds3.provenance.detail)
-    assert ds.provenance.detail == details
+#    assert repr(ds.provenance) == "<ObjectOrigin>"
+#    details  = "0: {0} \n".format(ds1.provenance.detail)
+#    details += "1: {0} \n".format(ds2.provenance.detail)
+#    details += "2: {0}".format(ds3.provenance.detail)
+#    assert ds.provenance.detail == details
     
     ds1_ = ds1.select("x > 1")
     ds2_ = ds2.select("x > 1")
@@ -139,15 +139,15 @@ def test_concatenate():
     
     assert ds_.nentries == ds.select("x > 1").nentries
     
-    assert repr(ds_.provenance) == "<ObjectOrigin>"
-    details  = "0: 0: {0}  \n".format(ds1_.provenance[0].detail)
-    details += "   1: {0} \n".format(ds1_.provenance[1].detail)
-    details += "1: 0: {0}  \n".format(ds2_.provenance[0].detail)
-    details += "   1: {0} \n".format(ds2_.provenance[1].detail)
-    details += "2: 0: {0}  \n".format(ds3_.provenance[0].detail)
-    details += "   1: {0}".format(ds3_.provenance[1].detail)
-    
-    assert ds_.provenance.detail == details
+#    assert repr(ds_.provenance) == "<ObjectOrigin>"
+#    details  = "0: 0: {0}  \n".format(ds1_.provenance[0].detail)
+#    details += "   1: {0} \n".format(ds1_.provenance[1].detail)
+#    details += "1: 0: {0}  \n".format(ds2_.provenance[0].detail)
+#    details += "   1: {0} \n".format(ds2_.provenance[1].detail)
+#    details += "2: 0: {0}  \n".format(ds3_.provenance[0].detail)
+#    details += "   1: {0}".format(ds3_.provenance[1].detail)
+#    
+#    assert ds_.provenance.detail == details
 
     
 def test_selections():

--- a/tests/dataset/test_numpydataset.py
+++ b/tests/dataset/test_numpydataset.py
@@ -110,7 +110,41 @@ def test_operations():
     print(c[0])
     assert c[0] == approx(np.exp(2))
     assert c.provenance[-1].detail == "exp( a )"
-
+    
+def test_concatenate():
+    
+    ar1 = np.array([(1,1),(2,2),(3,3)],dtype=[('x',int), ('y',int)])
+    ar2 = np.array([(4,-2),(0,7),(4,3)],dtype=[('x',int), ('y',int)])
+    ar3 = np.array([(3,-1),(2,5),(1,1)],dtype=[('x',int), ('y',int)])
+    
+    ds1 = NumpyDataset(ar1)
+    ds2 = NumpyDataset(ar2)
+    ds3 = NumpyDataset(ar3)
+    ds = concatenate([ds1, ds2, ds3])
+    
+    assert ds.nentries == ds1.nentries + ds2.nentries + ds3.nentries
+    assert ds[-1][0] == 1 
+    assert ds[-1][1] == 1
+    
+    assert repr(ds.provenance) == "<ObjectOrigin>"
+    details  = "0: {0} \n".format(ds1.provenance.detail)
+    details += "1: {0} \n".format(ds2.provenance.detail)
+    details += "2: {0}".format(ds3.provenance.detail)
+    assert str(ds.provenance.detail) == details
+    
+    ds1_ = ds1.select("x > 1")
+    ds2_ = ds2.select("x > 1")
+    ds3_ = ds3.select("x > 1")
+    ds_ = concatenate([ds1_, ds2_, ds3_])
+    
+    assert ds_.nentries == ds.select("x > 1").nentries
+    
+    assert repr(ds.provenance) == "<ObjectOrigin>"
+    details  = "0: {0} \n".format(ds1.provenance.detail)
+    details += "1: {0} \n".format(ds2.provenance.detail)
+    details += "2: {0}".format(ds3.provenance.detail)
+    assert str(ds.provenance.detail) == details
+    
 def test_selections():
     
     ar = np.array([(1,1),(2,2),(3,3)],dtype=[('x',int), ('y',int)])

--- a/tests/dataset/test_numpydataset.py
+++ b/tests/dataset/test_numpydataset.py
@@ -133,13 +133,13 @@ def test_concatenate():
     assert ds[-1][1] == 1
     
     assert repr(ds.provenance) == "<ObjectOrigin>"
-#    details  = "0: {0} \n".format(ds1.provenance.detail)
-#    details += "1: {0} \n".format(ds2.provenance.detail)
-#    details += "2: {0}".format(ds3.provenance.detail)
-#    assert ds.provenance.detail == details
-    assert ds1.provenance.detail in ds.provenance.detail
-    assert ds2.provenance.detail in ds.provenance.detail
-    assert ds2.provenance.detail in ds.provenance.detail
+    details  = "0: {0}\n".format(ds1.provenance.detail)
+    details += "1: {0}\n".format(ds2.provenance.detail)
+    details += "2: {0}".format(ds3.provenance.detail)
+    assert ds.provenance.detail == details
+#    assert ds1.provenance.detail in ds.provenance.detail
+#    assert ds2.provenance.detail in ds.provenance.detail
+#    assert ds2.provenance.detail in ds.provenance.detail
     
     
     ds1_ = ds1.select("x > 1")
@@ -150,23 +150,23 @@ def test_concatenate():
     assert ds_.nentries == ds.select("x > 1").nentries
     
     assert repr(ds_.provenance) == "<ObjectOrigin>"
-#    details  = "0: 0: {0}  \n".format(ds1_.provenance[0].detail)
-#    details += "   1: {0} \n".format(ds1_.provenance[1].detail)
-#    details += "1: 0: {0}  \n".format(ds2_.provenance[0].detail)
-#    details += "   1: {0} \n".format(ds2_.provenance[1].detail)
-#    details += "2: 0: {0}  \n".format(ds3_.provenance[0].detail)
-#    details += "   1: {0}".format(ds3_.provenance[1].detail)
-    for s in ds1_.provenance.detail.split("\n"):
-        assert s in ds_.provenance.detail
-    for s in ds2_.provenance.detail.split("\n"):
-        assert s in ds_.provenance.detail
-    for s in ds2_.provenance.detail.split("\n"):
-        assert s in ds_.provenance.detail
-#    assert ds1_.provenance.detail in ds_.provenance.detail
-#    assert ds2_.provenance.detail in ds_.provenance.detail
-#    assert ds2_.provenance.detail in ds_.provenance.detail
+    details  = "0: 0: {0}\n".format(ds1_.provenance[0].detail)
+    details += "   1: {0}\n".format(ds1_.provenance[1].detail)
+    details += "1: 0: {0}\n".format(ds2_.provenance[0].detail)
+    details += "   1: {0}\n".format(ds2_.provenance[1].detail)
+    details += "2: 0: {0}\n".format(ds3_.provenance[0].detail)
+    details += "   1: {0}".format(ds3_.provenance[1].detail)
+#    for s in ds1_.provenance.detail.split("\n"):
+#        assert s in ds_.provenance.detail
+#    for s in ds2_.provenance.detail.split("\n"):
+#        assert s in ds_.provenance.detail
+#    for s in ds2_.provenance.detail.split("\n"):
+#        assert s in ds_.provenance.detail
+##    assert ds1_.provenance.detail in ds_.provenance.detail
+##    assert ds2_.provenance.detail in ds_.provenance.detail
+##    assert ds2_.provenance.detail in ds_.provenance.detail
     
-#    assert ds_.provenance.detail == details
+    assert ds_.provenance.detail == details
 
 def test_selections():
     

--- a/tests/utils/test_provenance.py
+++ b/tests/utils/test_provenance.py
@@ -90,5 +90,5 @@ def test_MultiProvenance():
     multip1 = multip.copy() + MultiProvenance(forma)
     assert multip1[2].__repr__() == '<Formatting to ROOTDataset(DecayTree)>'
     assert multip1[2].detail == 'ROOTDataset(DecayTree)'
-    assert multip1.__repr__() == "0: {0} \n1: {1} \n2: {2}".format(prov1, transf, forma)
+    assert multip1.__repr__() == "0: {0}\n1: {1}\n2: {2}".format(prov1, transf, forma)
     multip2 = MultiProvenance(multip1)


### PR DESCRIPTION
Following #71 now it is possible to concatenate NumpyDataset which is pretty handy when using uproot.iterate.
New tests have also been added for this new function.