### PR TITLE
Add skhep.show_versions()

### DIFF
--- a/skhep/__init__.py
+++ b/skhep/__init__.py
@@ -3,16 +3,18 @@
 A community-driven and oriented Python software project for High Energy Physics.
 """
 
-# -----------------------------------------------------------------------------
-# Import statements
-# -----------------------------------------------------------------------------
 from __future__ import absolute_import
+
+from .utils._show_versions import show_versions
+
 
 __all__ = ['banner',
            'project_url',
            'project_url_GitHub',
-           'project_url_PyPI'
+           'project_url_PyPI',
+           'show_versions'
            ]
+
 
 # -----------------------------------------------------------------------------
 # Project and package info

--- a/skhep/utils/_show_versions.py
+++ b/skhep/utils/_show_versions.py
@@ -1,0 +1,101 @@
+# Licensed under a 3-clause BSD style license, see LICENSE.
+"""
+Utility methods to print system info and org packages info, for debugging.
+
+Heavily inspired from :func:`sklearn.show_versions`.
+"""
+
+import platform
+import sys
+import importlib
+
+
+scipy_deps = [
+        "pip",
+        "setuptools",
+        "numpy",
+        "scipy",
+        "pandas",
+        "matplotlib"
+]
+
+
+skhep_deps = [
+    "awkward",
+    "boost_histogram",
+    "decaylanguage",
+    "hepunits",
+    "iminuit",
+    "particle",
+    "uproot_methods",
+    "uproot"
+]
+
+
+def _get_sys_info():
+    """
+    Get system information.
+
+    Return
+    ------
+    sys_info : dict
+        System and Python version information.
+    """
+    python = sys.version.replace('\n', ' ')
+
+    blob = [
+        ("python", python),
+        ('executable', sys.executable),
+        ("machine", platform.platform()),
+    ]
+
+    return dict(blob)
+
+
+def _get_deps_info(pkgs_list):
+    """
+    Get the installed versions of a list of packages.
+
+    Returns
+    -------
+    deps_info: dict
+        Version information on the input list of libraries.
+
+    """
+    deps_info = {}
+
+    for modname in pkgs_list:
+        try:
+            if modname in sys.modules:
+                mod = sys.modules[modname]
+            else:
+                mod = importlib.import_module(modname)
+            ver = mod.__version__
+            deps_info[modname] = ver
+        except ImportError:
+            deps_info[modname] = None
+
+    return deps_info
+
+
+def show_versions():
+    """
+    Overview of the installed versions of main dependencies on the
+    Python scientific ecosystem packages and on the Scikit-HEP packages.
+    """
+
+    sys_info = _get_sys_info()
+    deps_info = _get_deps_info(scipy_deps)
+    skhep_deps_info = _get_deps_info(skhep_deps)
+
+    print('\nSystem:')
+    for k, stat in sys_info.items():
+        print("{k:>10}: {stat}".format(k=k, stat=stat))
+
+    print('\nPython dependencies:')
+    for k, stat in deps_info.items():
+        print("{k:>10}: {stat}".format(k=k, stat=stat))
+
+    print('\nScikit-HEP package dependencies:')
+    for k, stat in skhep_deps_info.items():
+        print("{k:>15}: {stat}".format(k=k, stat=stat))


### PR DESCRIPTION
Nice thing providing the following presently on my laptop - for the sake of example:

```
In [1]: import skhep

In [2]: skhep.show_versions()

System:
    python: 3.7.4 (default, Aug  9 2019, 18:34:13) [MSC v.1915 64 bit (AMD64)]
executable: C:\home\sw\Anaconda3\python.exe
   machine: Windows-10-10.0.18362-SP0

Python dependencies:
       pip: 19.2.3
setuptools: 41.4.0
     numpy: 1.16.5
     scipy: 1.3.1
    pandas: 0.25.1
matplotlib: 3.1.1

Scikit-HEP package dependencies:
        awkward: 0.12.14
boost_histogram: 0.5.0
  decaylanguage: 0.5.2
       hepunits: 1.0.0
        iminuit: 1.3.7
       particle: 0.6.2
 uproot_methods: 0.7.1
         uproot: 3.10.7
```