### PR TITLE
Particle, boost-histogram, hepunits, iminuit dependencies update, add Hist, mplhep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ iminuit~=1.3.0; python_version<"3.6"
 iminuit~=1.5.0; python_version>="3.6"
 numpy>=1.13.1
 matplotlib>2.0.0
-mplhelp~=0.2.2; python_version>="3.6"
+mplhelp~=0.2.0; python_version>="3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ iminuit~=1.3.0; python_version<"3.6"
 iminuit~=1.5.0; python_version>="3.6"
 numpy>=1.13.1
 matplotlib>2.0.0
-mplhelp~=0.2.0; python_version>="3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hepunits~=1.2.0
+hepunits~=2.0.0
 particle~=0.12.0
 decaylanguage~=0.8.0
 awkward~=0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 hepunits~=1.2.0
 particle~=0.12.0
-decaylanguage~=0.7.0
+decaylanguage~=0.8.0
 awkward~=0.12
 uproot-methods~=0.7.0
 uproot~=3.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,9 @@ awkward~=0.12
 uproot-methods~=0.7.0
 uproot~=3.12.0
 boost-histogram~=0.11.0
-iminuit~=1.4.0
+hist~=2.0.0; python_version>="3.6"
+iminuit~=1.3.0; python_version<"3.6"
+iminuit~=1.5.0; python_version>="3.6"
 numpy>=1.13.1
 matplotlib>2.0.0
+mplhelp~=0.2.2; python_version>="3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ iminuit~=1.3.0; python_version<"3.6"
 iminuit~=1.5.0; python_version>="3.6"
 numpy>=1.13.1
 matplotlib>2.0.0
+mplhep~=0.2.0; python_version>="3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 hepunits~=1.2.0
-particle~=0.11.0
+particle~=0.12.0
 decaylanguage~=0.7.0
 awkward~=0.12
 uproot-methods~=0.7.0
 uproot~=3.12.0
-boost-histogram~=0.10.0
+boost-histogram~=0.11.0
 iminuit~=1.4.0
 numpy>=1.13.1
 matplotlib>2.0.0

--- a/requirements_current_release.txt
+++ b/requirements_current_release.txt
@@ -7,4 +7,4 @@ boost-histogram
 hist
 iminuit
 matplotlib
-mplhelp
+mplhep

--- a/requirements_current_release.txt
+++ b/requirements_current_release.txt
@@ -4,5 +4,7 @@ decaylanguage
 awkward
 uproot
 boost-histogram
+hist
 iminuit
 matplotlib
+mplhelp

--- a/skhep/utils/_show_versions.py
+++ b/skhep/utils/_show_versions.py
@@ -25,7 +25,9 @@ skhep_deps = [
     "boost_histogram",
     "decaylanguage",
     "hepunits",
+    "hist",
     "iminuit",
+    "mplhep",
     "particle",
     "uproot_methods",
     "uproot"


### PR DESCRIPTION
@henryiii, you had asked to wait for BH 0.11 to make a first scikit-hep metapackage release. This seems to be the last step required for the (long due) release. Anything else you would like in? We can be fancier in the future but I think it really is about time that we get this out. We should then get scikit-hep on conda, as that's where it will be even more useful ...