### PR TITLE
Don't install "tests" directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     long_description=read('README.rst'),
     url=URL,
     license=LICENSE,
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests",)),
     py_modules=['setuputils'],
     python_requires=PYTHON_REQUIRES,
     install_requires=INSTALL_REQUIRES,


### PR DESCRIPTION
I noticed in https://github.com/conda-forge/staged-recipes/pull/12786 that the `tests/` directory is being installed to `site-packages` as it isn't explicitly excluded.