### PR TITLE
Add requirements.txt to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,6 @@ recursive-include tests *
 
 # Include documentation in reStructuredText format
 recursive-include doc *
+
+# Required by setup.py script
+requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,14 +1,7 @@
-# Include the license file
-include LICENSE
-
-# Include the MANIFEST itself
-include MANIFEST.in
+include LICENSE requirements.txt
 
 # Include directory with test suite
 recursive-include tests *
 
 # Include documentation in reStructuredText format
 recursive-include doc *
-
-# Required by setup.py script
-requirements.txt


### PR DESCRIPTION
Fixes the failure when installing from the sdist:

```
Processing $SRC_DIR
  Created temporary directory: /tmp/pip-req-build-kjlpa82m
  Added file://$SRC_DIR to build tracker '/tmp/pip-req-tracker-m00rkbjg'
    Running command python setup.py egg_info
    Running setup.py (path:/tmp/pip-req-build-kjlpa82m/setup.py) egg_info for package from file://$SRC_DIR
    Created temporary directory: /tmp/pip-pip-egg-info-qq8rm6bn
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-kjlpa82m/setup.py", line 25, in <module>
        with open(os.path.join(LOCAL_PATH, 'requirements.txt')) as requirements_file:
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-req-build-kjlpa82m/requirements.txt'
```

See https://github.com/conda-forge/staged-recipes/pull/12786