### PR TITLE
MANIFEST.in - Do not recursively include docs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,1 @@
 include LICENSE requirements.txt
-
-# Include directory with test suite
-recursive-include tests *
-
-# Include documentation in reStructuredText format
-recursive-include doc *


### PR DESCRIPTION
Follow-up from PR https://github.com/scikit-hep/scikit-hep/pull/117 on adaptation of the `MANIFEST.in` file:
- No need to add the docs of features that we want to get removed now that this package is a metapackage.
- Do not install the tests directory is already specified in `setup.py`, see PR https://github.com/scikit-hep/scikit-hep/pull/114.