### PR TITLE
Drop Python 2 support !

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.8]
+        python-version: [3.6, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,8 @@ awkward~=0.12
 uproot-methods~=0.7.0
 uproot~=3.12.0
 boost-histogram~=0.11.0
-hist~=2.0.0; python_version>="3.6"
-iminuit~=1.3.0; python_version<"3.6"
-iminuit~=1.5.0; python_version>="3.6"
+hist~=2.0.0
+iminuit~=1.5.0
 numpy>=1.13.1
 matplotlib>2.0.0
-mplhep~=0.2.0; python_version>="3.6"
+mplhep~=0.2.0

--- a/setup.py
+++ b/setup.py
@@ -20,13 +20,13 @@ VERSION = find_version('skhep/__init__.py')
 
 LOCAL_PATH = os.path.dirname(os.path.abspath(__file__))
 
-PYTHON_REQUIRES = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+PYTHON_REQUIRES = ">=3.6"
 
 with open(os.path.join(LOCAL_PATH, 'requirements.txt')) as requirements_file:
     INSTALL_REQUIRES = requirements_file.read().splitlines()
 
 TESTS_REQUIRE = [
-    'pytest>3.0;python_version>="2.7"'
+    'pytest>3.0'
 ]
 
 setup(
@@ -54,8 +54,6 @@ setup(
         'Operating System :: MacOS',
         'License :: OSI Approved',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Towards a release 1.1.0 that ony supports Python >= 3.6 but is otherwise identical to 1.0.0.