### PR TITLE
Bump to 1.2.1

### DIFF
--- a/skhep/__init__.py
+++ b/skhep/__init__.py
@@ -19,7 +19,7 @@ __all__ = ['banner',
 # -----------------------------------------------------------------------------
 # Project and package info
 # -----------------------------------------------------------------------------
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 
 project_url = 'http://scikit-hep.org'
 project_url_GitHub = 'https://github.com/scikit-hep/scikit-hep'


### PR DESCRIPTION
Trivially identical to version 1.2.0 except for `iminuit 1.4.x` versions pinned since the 1.5.x series have unresolved (performance) issues.

FYI @HDembinski.