### PR TITLE
New versions of awkward, boost-histogram, hepunits, hist, histoprint, iminuit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 awkward~=1.1.0
 awkward0~=0.15
-boost-histogram~=0.12.0
+boost-histogram~=0.13.0
 decaylanguage~=0.10.0
 hepstats~=0.3.0
-hepunits~=2.0.0
-hist~=2.0.0
+hepunits~=2.1.0
+hist~=2.1.0
 histoprint~=1.6.0
 iminuit~=1.4.0
 matplotlib>2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ hepstats~=0.3.0
 hepunits~=2.1.0
 hist~=2.1.0
 histoprint~=1.6.0
-iminuit~=1.4.0
+iminuit~=2.4.0
 matplotlib>2.0.0
 mplhep~=0.2.0
 numpy>=1.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-awkward~=1.0.0
+awkward~=1.1.0
 awkward0~=0.15
-boost-histogram~=0.11.0
+boost-histogram~=0.12.0
 decaylanguage~=0.10.0
 hepstats~=0.3.0
 hepunits~=2.0.0
 hist~=2.0.0
-histoprint~=1.5.0
+histoprint~=1.6.0
 iminuit~=1.4.0
 matplotlib>2.0.0
 mplhep~=0.2.0

--- a/skhep/_version.py
+++ b/skhep/_version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "1.4.0"
+__version__ = "2.0.0"

--- a/skhep/_version.py
+++ b/skhep/_version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "1.3.0"
+__version__ = "1.4.0"


### PR DESCRIPTION
Preparing a new scikit-hep release. For reference, the diff is the following:
```
-awkward~=1.0.0
+awkward~=1.1.0
-boost-histogram~=0.11.0
+boost-histogram~=0.13.0
-hepunits~=2.0.0
+hepunits~=2.1.0
-hist~=2.0.0
+hist~=2.1.0
-histoprint~=1.5.0
+histoprint~=1.6.0
-iminuit~=1.4.0
+iminuit~=2.4.0
```

 @HDembinski, I did not update `iminuit`, still pinned as `iminuit~=1.4.0` but assume you would now recommend to move to version `~2.4.0`? Advance thanks.