### PR TITLE
ci: Migrate coverage reporting to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,14 +37,17 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install pytest pytest-cov coveralls>=3.3
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install pytest pytest-cov
+
     - name: Install package
       run: python -m pip install .
+
     - name: Test with pytest
-      run: pytest --cov=skhep tests
-    - name: Send to coveralls
-      if: matrix.python-version == 3.8
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      run: coveralls --service=github
+      run: pytest tests
+
+    - name: Report coverage with Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./coverage.xml
+        flags: unittests-${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -20,9 +20,8 @@
 .. image:: https://github.com/scikit-hep/scikit-hep/workflows/CI/badge.svg
    :target: https://github.com/scikit-hep/scikit-hep/actions?query=workflow%3ACI+branch%3Amaster
 
-.. image:: https://coveralls.io/repos/github/scikit-hep/scikit-hep/badge.svg?branch=master
-   :target: https://coveralls.io/github/scikit-hep/scikit-hep?branch=master
-
+.. image:: https://codecov.io/gh/scikit-hep/scikit-hep/graph/badge.svg?branch=master
+   :target: https://codecov.io/gh/scikit-hep/scikit-hep?branch=master
 
 Project info
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ minversion = "6.0"
 xfail_strict = true
 addopts = [
     "-ra",
-    "--cov=hepdata_lib",
+    "--cov=skhep",
     "--cov-branch",
     "--showlocals",
     "--strict-markers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,20 @@ requires = [
 ]
 
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+xfail_strict = true
+addopts = [
+    "-ra",
+    "--cov=hepdata_lib",
+    "--cov-branch",
+    "--showlocals",
+    "--strict-markers",
+    "--strict-config",
+    "--cov-report=term-missing",
+    "--cov-report=xml",
+    "--cov-report=html",
+]
+log_cli_level = "info"
+testpaths = "tests"


### PR DESCRIPTION
Working with Coveralls for Python testing is a huge pain in my experience (which is why `pyhf` left it for Codecov years ago) and why I'm trying to help other projects move away from it &mdash; c.f. https://github.com/HEPData/hepdata_lib/pull/199.

This PR migrates coverage reporting to use Codecov via their GitHub Action and also adds pytest run options into `pyproject.toml` for easier running (now you just run `pytest` instead of having to pass flags). Coverage is reported for each Python version with a different "flag" and they are all summarized by Codecov.

Resolves #219