### PR TITLE
ci: Drop use of pip's '2020-resolver' feature preview

### DIFF
--- a/.github/workflows/current_releases.yml
+++ b/.github/workflows/current_releases.yml
@@ -8,13 +8,14 @@ on:
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ["3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/current_releases.yml
+++ b/.github/workflows/current_releases.yml
@@ -25,11 +25,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --use-feature=2020-resolver pytest pytest-cov coveralls>=1.9.2
+        python -m pip install pytest pytest-cov coveralls>=1.9.2
     - name: Install package and upgrade dependencies to PyPI current release
       run: |
-        python -m pip install --use-feature=2020-resolver .
-        python -m pip install --upgrade --use-feature=2020-resolver -r requirements_current_release.txt
+        python -m pip install .
+        python -m pip install --upgrade -r requirements_current_release.txt
         python -m pip list
     - name: Test with pytest
       run: pytest --cov=skhep tests


### PR DESCRIPTION
* The 2020 resolver option is now the default and its use is causing errors during CI now.
* Add workflow_dispatch trigger.

Similar example of the `2020-resolver` causing problems: https://github.com/kratsg/drstorage/pull/66