### PR TITLE
Roll back to iminuit 2.22.0 to have Conda releases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ hepstats~=0.7.0
 hepunits~=2.3.0
 hist~=2.7.0
 histoprint~=2.4.0
-iminuit~=2.24.0
+iminuit~=2.22.0
 matplotlib>3.4.0
 mplhep~=0.3.0
 numpy>=1.13.1


### PR DESCRIPTION
Indeed necessary given that 2.23.0 and 2.24.0 are not available for most arch in Conda, hence I cannot really make a scikit-hep release in conda, see https://github.com/conda-forge/scikit-hep-feedstock/pull/20 and links therein.