### PR TITLE
Remove unnecessary explicit dependency on boost-histogram

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 awkward~=2.4.0
-boost-histogram~=1.4.0
 decaylanguage~=0.16.0
 hepstats~=0.7.0
 hepunits~=2.3.0

--- a/requirements_current_release.txt
+++ b/requirements_current_release.txt
@@ -1,5 +1,4 @@
 awkward
-boost-histogram
 decaylanguage
 hepstats
 hepunits


### PR DESCRIPTION
This is safe and remove the unnecessary strictness in my opinion.