### PR TITLE
fix: show_versions fix and 500x speedup

### DIFF
--- a/skhep/utils/_show_versions.py
+++ b/skhep/utils/_show_versions.py
@@ -8,10 +8,10 @@ Heavily inspired from :func:`sklearn.show_versions`.
 
 import platform
 import sys
-import importlib
+import importlib.metadata
 
 
-scipy_deps = ["pip", "setuptools", "numpy", "scipy", "pandas", "matplotlib"]
+scipy_deps = ["setuptools", "pip", "numpy", "scipy", "pandas", "matplotlib"]
 
 
 skhep_deps = [
@@ -67,13 +67,8 @@ def _get_deps_info(pkgs_list):
 
     for modname in pkgs_list:
         try:
-            if modname in sys.modules:
-                mod = sys.modules[modname]
-            else:
-                mod = importlib.import_module(modname)
-            ver = mod.__version__
-            deps_info[modname] = ver
-        except ImportError:
+            deps_info[modname] = importlib.metadata.version(modname)
+        except ModuleNotFoundError:
             deps_info[modname] = None
 
     return deps_info

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from skhep import show_versions
+
+
+def test_show_versions():
+    show_versions()


### PR DESCRIPTION
Makes this 500x faster by not importing a bunch of code just to get the versions.

Fix #332.
