### PR TITLE
ci: fix dependabot updating ~ patches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     reviewers:
       - "eduardo-rodrigues"
     commit-message:
-      prefix: "chore GHA deps:"
+      prefix: "chore(GHA deps):"
 
   # Maintain dependencies for python
   - package-ecosystem: "pip"
@@ -21,7 +21,5 @@ updates:
     reviewers:
       - "eduardo-rodrigues"
     commit-message:
-      prefix: "chore pip deps:"
-    ignore:
-       - dependency-name: "*"
-         update-types: ["version-update:semver-patch"]
+      prefix: "chore(pip deps):"
+    versioning-strategy: "increase-if-necessary"


### PR DESCRIPTION
I'm not sure this fixes it, but I think it might. Based on https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy (and it says they are supported for pip).

Also make the prefixes proper conventionalcommits style.