### PR TITLE
chore: add 3.13 classifier and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     "setuptools>=42.0",
 ]
-
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
   Programming Language :: Python :: 3.12
+  Programming Language :: Python :: 3.13
   Programming Language :: C++
   Programming Language :: Cython
   Development Status :: 4 - Beta
@@ -33,7 +34,7 @@ packages = find:
 
 [options.extras_require]
 test =
-  pytest >=6.0,<8.1.0  #  cap because of https://github.com/pytest-dev/pytest/issues/11779
+  pytest >=7.0
   pytest-cov
 
 [options.packages.find]


### PR DESCRIPTION
Adding 3.13. The two remaining packages without a 3.13 classifier should support it.
